### PR TITLE
Fix batch of bugs in ESPMaster firmware and web UI

### DIFF
--- a/ESPMaster/ESPMaster.ino
+++ b/ESPMaster/ESPMaster.ino
@@ -341,7 +341,6 @@ void setup() {
       SerialPrintln("Request to Remove Scheduled Message Received");
       
       if (request->hasParam(PARAM_ID)) {
-        bool removedScheduledMessage = false;
         String idValue = request->getParam(PARAM_ID)->value();
 
         if (isNumber(idValue)) {
@@ -371,8 +370,9 @@ void setup() {
 
       bool submissionError = false;
       
-      long newMessageScheduleDateTimeUnixValue;
-      bool newMessageScheduleEnabledValue, newMessageScheduleShowIndefinitely;
+      long newMessageScheduleDateTimeUnixValue = 0;
+      bool newMessageScheduleEnabledValue = false;
+      bool newMessageScheduleShowIndefinitely = false;
       String newAlignmentValue, newDeviceModeValue, newFlapSpeedValue, newInputTextValue, newCountdownToDateUnixValue;
       
       int params = request->params();
@@ -458,7 +458,7 @@ void setup() {
       //If there was an error, report back to check what has been input
       if (submissionError) {
         SerialPrintln("Finished Processing Request with Error");
-        request->redirect("/?invalid-submission=" + true);
+        request->redirect("/?invalid-submission=true");
       }
       else {
         SerialPrintln("Finished Processing Request Successfully");
@@ -529,8 +529,8 @@ void setup() {
       html += "<p>Open your Arduino IDE and select the new port in \"Tools\" menu and upload the your sketch as normal!</p>";
       html += "<p>After you have carried out your update, the system will automatically be rebooted. You can go to the main home page after this time by clicking the button below or going to '/'.</p>";
       html += "<p>You can take the system out of this mode by clicking the button to reboot below or going to '/reboot'.</p>";
-      html += "<p><a href=\"http://" + ip.toString() + "\")\">Home</a></p>";
-      html += "<p><a href=\"http://" + ip.toString() + "/reboot\")\">Reboot</a></p>";
+      html += "<p><a href=\"http://" + ip.toString() + "\">Home</a></p>";
+      html += "<p><a href=\"http://" + ip.toString() + "/reboot\">Reboot</a></p>";
       html += "</font>";
       html += "</div>";
 
@@ -541,7 +541,7 @@ void setup() {
         ArduinoOTA.setHostname("Split-Flap-OTA");
 
         //If there is a password set, disabled by default for ease
-        if (otaPassword != "") {
+        if (strlen(otaPassword) > 0) {
           ArduinoOTA.setPassword(otaPassword);
         }
         

--- a/ESPMaster/HelpersStringHandling.ino
+++ b/ESPMaster/HelpersStringHandling.ino
@@ -4,6 +4,12 @@ String cleanString(String message);
 
 //Aligns string on center of array and fills empty chars with spaces
 String centerString(String message) {
+  //Overflow-safe: if the message is already at or over the display width,
+  //truncate rather than wrap int/unsigned subtraction into a huge loop.
+  if (message.length() >= (unsigned int)UNITS_AMOUNT) {
+    return cleanString(message.substring(0, UNITS_AMOUNT));
+  }
+
   //Takes care of the left side
   int leftSpaceAmount = (UNITS_AMOUNT -  message.length()) / 2;
   for (int spaceIndex = 0; spaceIndex < leftSpaceAmount; spaceIndex++) {
@@ -16,7 +22,7 @@ String centerString(String message) {
   }
 
   message = cleanString(message);
-  
+
   return message;
 }
 
@@ -31,6 +37,10 @@ String createRepeatingString(char character) {
 
 //Aligns string on right side of array and fills empty chars with spaces
 String rightString(String message) {
+  if (message.length() >= (unsigned int)UNITS_AMOUNT) {
+    return cleanString(message.substring(0, UNITS_AMOUNT));
+  }
+
   int rightSpaceAmount = (UNITS_AMOUNT - message.length());
   for (int spaceIndex = 0; spaceIndex < rightSpaceAmount; spaceIndex++) {
     message = " " + message;
@@ -43,6 +53,10 @@ String rightString(String message) {
 
 //Aligns string on left side of array and fills empty chars with spaces
 String leftString(String message) {
+  if (message.length() >= (unsigned int)UNITS_AMOUNT) {
+    return cleanString(message.substring(0, UNITS_AMOUNT));
+  }
+
   int leftSpaceAmount = (UNITS_AMOUNT - message.length());
   for (int spaceIndex = 0; spaceIndex < leftSpaceAmount; spaceIndex++) {
     message = message + " ";
@@ -199,10 +213,16 @@ LList<String> processSentenceToLines(String sentence) {
 
 //Used for ensuring a string is a number
 bool isNumber(String str) {
+  //Empty string is not a number; strtol would leave endPtr at the input
+  //start which also points at '\0', causing a false positive.
+  if (str.length() == 0) {
+    return false;
+  }
+
   char* endPtr;
 
   //10 specifies base 10 (decimal)
-  strtol(str.c_str(), &endPtr, 10);  
+  strtol(str.c_str(), &endPtr, 10);
 
   //Check if the conversion reached the end of the string
   return (*endPtr == '\0');

--- a/ESPMaster/ServiceCountdownFunctions.ino
+++ b/ESPMaster/ServiceCountdownFunctions.ino
@@ -18,7 +18,7 @@ void checkCountdown() {
     String daysText = String(days) + (days == 1 ? " day" : " days");
     if (daysText.length() > UNITS_AMOUNT) {
       SerialPrintln("Days Text was too long, cutting down to just the number...");
-      daysText = "" + days;
+      daysText = String(days);
     }
 
     if (inputText != daysText) {

--- a/ESPMaster/ServiceFileSystemFunctions.ino
+++ b/ESPMaster/ServiceFileSystemFunctions.ino
@@ -50,11 +50,10 @@ String readFile(fs::FS &fs, const char * path, String defaultValue) {
     return String();
   }
 
-  String fileContent;
-  while (file.available()) {
-    fileContent = file.readStringUntil('\n');
-    break;
-  }
+  //readString pulls the whole file; readStringUntil('\n') would truncate
+  //multi-line blobs like the scheduled-messages JSON.
+  String fileContent = file.readString();
+  file.close();
   return fileContent;
 }
 
@@ -70,8 +69,10 @@ void writeFile(fs::FS &fs, const char * path, const char * message) {
   
   if (file.print(message)) {
     SerialPrintln("- File written");
-  } 
+  }
   else {
     SerialPrintln("- Write failed");
   }
+
+  file.close();
 }

--- a/ESPMaster/ServiceScheduledMessageFunctions.ino
+++ b/ESPMaster/ServiceScheduledMessageFunctions.ino
@@ -57,7 +57,9 @@ bool removeScheduledMessage(long scheduledDateTimeUnix) {
 void checkScheduledMessages() {   
   //Iterate over the current bunch of scheduled messages. If we find one where the current time exceeds when we should show
   //the message, then we need to show that message immediately
-  unsigned long currentTimeUnix = timezone.now();
+  //`ScheduledDateTimeUnix` is declared `long` in Classes.h; match the type to
+  //avoid signed/unsigned comparison surprises.
+  long currentTimeUnix = timezone.now();
   for(int scheduledMessageIndex = 0; scheduledMessageIndex < scheduledMessages.size(); scheduledMessageIndex++) {
     ScheduledMessage scheduledMessage = scheduledMessages[scheduledMessageIndex];
 

--- a/ESPMaster/ServiceWifiFunctions.ino
+++ b/ESPMaster/ServiceWifiFunctions.ino
@@ -49,7 +49,7 @@ void initWiFi() {
 #else
   SerialPrintln("Setting up WiFi Direct");
 
-  if (wifiDirectSsid != "" && wifiDirectPassword != "") {
+  if (strlen(wifiDirectSsid) > 0 && strlen(wifiDirectPassword) > 0) {
     int maxAttemptsCount = 0;
     
 #if WIFI_STATIC_IP == true

--- a/ESPMaster/data/script.js
+++ b/ESPMaster/data/script.js
@@ -288,7 +288,7 @@ function setCountdownDate(dateUnix) {
 		if (countdownDate >= currentDate) {
 			currentCountdownDate.value = convertDateToString(countdownDate);
 
-			if (countdownDate - currentDate < 24000) {
+			if (countdownDate - currentDate < 24 * 60 * 60 * 1000) {
 				currentCountdownDate.min = convertDateToString(nextDayDate);
 				return;
 			}
@@ -354,9 +354,9 @@ function showScheduledMessages(scheduledMessages) {
 	//Closest to being shown first
 	scheduledMessages = scheduledMessages.sort((a, b) => a.scheduledDateTimeUnix - b.scheduledDateTimeUnix);
 
-	for (var scheduledMessageIndex = 0; scheduledMessageIndex < scheduledMessages.length; scheduledMessageIndex++) {
-		var scheduledMessage = scheduledMessages[scheduledMessageIndex];
+	var container = document.getElementById("containerScheduledMessages");
 
+	scheduledMessages.forEach(function(scheduledMessage) {
 		//Create a container for a message
 		var messageElement = document.createElement("div");
 		messageElement.className = "message";
@@ -365,23 +365,34 @@ function showScheduledMessages(scheduledMessages) {
 		var timeElement = document.createElement("div");
 		timeElement.className = "time";
 		timeElement.innerText = new Date((scheduledMessage.scheduledDateTimeUnix * 1000) + (timezoneOffset * 60000)).toString().slice(0, -34);
-		
-		//Create a element to show the indefinite...ness...
-		var message = `<b>Message:</b> ${scheduledMessage.message.trim() == "" ? "<Blank>" : scheduledMessage.message}` 
-		var isIndefinitely = `<b>Shown Indefinitely:</b> ${scheduledMessage.showIndefinitely ? "Yes" : "No"}`;
 
-		//Create a element to show the text
+		//Create a element to show the text. Build via DOM + textContent so user
+		//message text can't inject HTML (previously interpolated into innerHTML).
 		var textElement = document.createElement("div");
 		textElement.className = "text";
-		textElement.innerHTML = `${message}<br>${isIndefinitely}`;
 
-		//Create a remove button
+		var messageLabel = document.createElement("b");
+		messageLabel.textContent = "Message:";
+		var displayMessage = scheduledMessage.message.trim() == "" ? "<Blank>" : scheduledMessage.message;
+		textElement.appendChild(messageLabel);
+		textElement.appendChild(document.createTextNode(" " + displayMessage));
+		textElement.appendChild(document.createElement("br"));
+
+		var indefiniteLabel = document.createElement("b");
+		indefiniteLabel.textContent = "Shown Indefinitely:";
+		textElement.appendChild(indefiniteLabel);
+		textElement.appendChild(document.createTextNode(" " + (scheduledMessage.showIndefinitely ? "Yes" : "No")));
+
+		//Create a remove button. Use addEventListener so message text isn't
+		//interpolated into an onclick attribute string.
 		var actionElement = document.createElement("div");
 		var actionButtonElement = document.createElement("span");
 		actionElement.className = "action";
 		actionButtonElement.className = "remove-button";
 		actionButtonElement.innerText = "Remove";
-		actionButtonElement.setAttribute('onclick', `deleteScheduledMessage(${scheduledMessage.scheduledDateTimeUnix}, '${scheduledMessage.message}')`);
+		actionButtonElement.addEventListener('click', function() {
+			deleteScheduledMessage(scheduledMessage.scheduledDateTimeUnix, scheduledMessage.message);
+		});
 		actionElement.appendChild(actionButtonElement);
 
 		//Add all the elements to the message
@@ -389,10 +400,8 @@ function showScheduledMessages(scheduledMessages) {
 		messageElement.appendChild(textElement);
 		messageElement.appendChild(actionElement);
 
-		//Append to the message container
-		var container = document.getElementById("containerScheduledMessages");
 		container.appendChild(messageElement);
-	}
+	});
 }
 
 function showContent() {

--- a/ESPMaster/test/test_string_handling/test_main.cpp
+++ b/ESPMaster/test/test_string_handling/test_main.cpp
@@ -31,8 +31,9 @@ static void test_isNumber_rejects_letters() {
   TEST_ASSERT_FALSE(isNumber(String("abc")));
   TEST_ASSERT_FALSE(isNumber(String("12a")));
 }
-// NOTE: isNumber("") currently returns true — a bug tracked in issue #1.
-// The assertion for empty-string rejection will be re-added once #1 lands.
+static void test_isNumber_rejects_empty() {
+  TEST_ASSERT_FALSE(isNumber(String("")));
+}
 
 // convertSpeed: maps 1..100 -> MIN_SPEED..MAX_SPEED (1..12)
 static void test_convertSpeed_endpoints() {
@@ -82,11 +83,31 @@ static void test_centerString_odd_remainder() {
   TEST_ASSERT_EQUAL_STRING("   HEY    ", s.c_str());
 }
 
+// Overflow guard: a message longer than UNITS_AMOUNT must not spin the padding
+// loop forever (it used to, because `UNITS_AMOUNT - message.length()` wrapped
+// in unsigned arithmetic). It should truncate cleanly instead.
+static void test_centerString_longer_than_display() {
+  String s = centerString(String("ABCDEFGHIJKL"));
+  TEST_ASSERT_EQUAL_INT(UNITS_AMOUNT, (int)s.length());
+  TEST_ASSERT_EQUAL_STRING("ABCDEFGHIJ", s.c_str());
+}
+static void test_leftString_longer_than_display() {
+  String s = leftString(String("ABCDEFGHIJKL"));
+  TEST_ASSERT_EQUAL_INT(UNITS_AMOUNT, (int)s.length());
+  TEST_ASSERT_EQUAL_STRING("ABCDEFGHIJ", s.c_str());
+}
+static void test_rightString_longer_than_display() {
+  String s = rightString(String("ABCDEFGHIJKL"));
+  TEST_ASSERT_EQUAL_INT(UNITS_AMOUNT, (int)s.length());
+  TEST_ASSERT_EQUAL_STRING("ABCDEFGHIJ", s.c_str());
+}
+
 int main(int, char**) {
   UNITY_BEGIN();
   RUN_TEST(test_isNumber_accepts_positive_integer);
   RUN_TEST(test_isNumber_accepts_negative_integer);
   RUN_TEST(test_isNumber_rejects_letters);
+  RUN_TEST(test_isNumber_rejects_empty);
   RUN_TEST(test_convertSpeed_endpoints);
   RUN_TEST(test_createRepeatingString_length_matches_units);
   RUN_TEST(test_cleanString_uppercases);
@@ -94,5 +115,8 @@ int main(int, char**) {
   RUN_TEST(test_rightString_pads_left);
   RUN_TEST(test_centerString_even_padding);
   RUN_TEST(test_centerString_odd_remainder);
+  RUN_TEST(test_centerString_longer_than_display);
+  RUN_TEST(test_leftString_longer_than_display);
+  RUN_TEST(test_rightString_longer_than_display);
   return UNITY_END();
 }


### PR DESCRIPTION
Closes #1.

## Summary

- All 8 "broken" items in #1 fixed
- Both "fragile" items fixed (they were small diffs)
- One bonus: surfaced by the native tests — `isNumber("")` returned true, also fixed here
- Sign/unsigned comparison warning in `checkScheduledMessages` silenced by matching types
- Dead `bool removedScheduledMessage` local removed
- New regression tests: `isNumber("")`, plus overflow-guard tests for `centerString`/`leftString`/`rightString` with over-long input. 14/14 pass, zero sketch-file warnings remain.

## Test plan

- [x] `pio test -e native` — 14/14 pass
- [x] `pio run -e espmaster` — clean build, no warnings in our code
- [ ] Flash to physical display, check: text mode, clock, date, countdown, schedule-for-later, OTA-mode link
- [ ] In text mode, send a message longer than `UNITS_AMOUNT` — should truncate and display, not hang
- [ ] In countdown mode, check the min-date input respects the 24-hour window

## Notes

Items intentionally left out of this PR per #1:
- Scheduled-message keying collisions (breaking API change)
- OTA-during-long-message timing (not reproducible enough to justify the complexity)