### PR TITLE
Fix I2C address 0 conflict and probe bus at boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.elf
 *.bin
 *.hex
+.claude/

--- a/ESPMaster/ESPMaster.h
+++ b/ESPMaster/ESPMaster.h
@@ -10,3 +10,9 @@
 
 String readFile(fs::FS& fs, const char* path, String defaultValue);
 void writeFile(fs::FS& fs, const char* path, const char* message);
+
+// Populated by probeI2cBus() in ServiceFlapFunctions.ino and read by
+// getCurrentSettingValues() in ESPMaster.ino (which comes earlier in the
+// alphabetical concatenation order, so needs the forward declaration).
+extern int detectedUnitCount;
+extern int detectedUnitAddresses[];

--- a/ESPMaster/ESPMaster.ino
+++ b/ESPMaster/ESPMaster.ino
@@ -276,6 +276,10 @@ void setup() {
     initialiseFileSystem();
     loadValuesFromFileSystem();
 
+    //Scan the I2C bus so we know how many units actually answered. Result is
+    //exposed via /settings so the UI can warn about a mismatch.
+    probeI2cBus();
+
 #if OTA_ENABLE == true
     SerialPrintln("OTA is enabled! Yay!");
 #endif
@@ -738,6 +742,10 @@ String getCurrentSettingValues() {
 
   document["timezoneOffset"] = timezone.getOffset();
   document["unitCount"] = UNITS_AMOUNT;
+  document["detectedUnitCount"] = detectedUnitCount;
+  for (int i = 0; i < detectedUnitCount; i++) {
+    document["detectedUnitAddresses"][i] = detectedUnitAddresses[i];
+  }
   document["alignment"] = alignment;
   document["flapSpeed"] = flapSpeed;
   document["deviceMode"] = deviceMode;

--- a/ESPMaster/ServiceFlapFunctions.ino
+++ b/ESPMaster/ServiceFlapFunctions.ino
@@ -1,3 +1,12 @@
+// I2C address 0x00 is reserved (general call); offset every unit's address so
+// the master's 0-based unit index maps to 0x01..0x10. Must match
+// I2C_ADDRESS_BASE in Unit/Unit.ino.
+#define I2C_ADDRESS_BASE 1
+
+static int toI2cAddress(int unitIndex) {
+  return I2C_ADDRESS_BASE + unitIndex;
+}
+
 //Shows a new message on the display
 void showText(String message) {  
   showText(message, 0);
@@ -118,11 +127,11 @@ int translateLettertoInt(char letterchar) {
   return -1;
 }
 
-//Write letter position and speed in rpm to single unit
-void writeToUnit(int address, int letter, int flapSpeed) {
+//Write letter position and speed in rpm to single unit (by 0-based unit index).
+void writeToUnit(int unitIndex, int letter, int flapSpeed) {
   int sendArray[2] = {letter, flapSpeed}; //Array with values to send to unit
 
-  Wire.beginTransmission(address);
+  Wire.beginTransmission(toI2cAddress(unitIndex));
 
   //Write values to send to slave in buffer
   for (unsigned int index = 0; index < sizeof sendArray / sizeof sendArray[0]; index++) {
@@ -154,21 +163,50 @@ bool isDisplayMoving() {
   return false;
 }
 
-//Checks if single unit is moving
-int checkIfMoving(int address) {
+//Checks if single unit is moving (by 0-based unit index).
+int checkIfMoving(int unitIndex) {
+  int i2cAddress = toI2cAddress(unitIndex);
   int active;
-  Wire.requestFrom(address, ANSWER_SIZE, 1);
+  Wire.requestFrom(i2cAddress, ANSWER_SIZE, 1);
   active = Wire.read();
 
-  SerialPrint(address);
+  SerialPrint(i2cAddress);
   SerialPrint(":");
   SerialPrintln(active);
 
   if (active == -1) {
     SerialPrintln("Try to wake up unit");
-    Wire.beginTransmission(address);
+    Wire.beginTransmission(i2cAddress);
     Wire.endTransmission();
   }
-  
+
   return active;
+}
+
+//Scans the I2C bus once for responders in the range reserved for units.
+//Populates `detectedUnitCount` and `detectedUnitAddresses` for the /settings
+//endpoint and logs the result over serial. No-op when SERIAL_ENABLE is true
+//(I2C is disabled in that mode) or UNIT_CALLS_DISABLE is true.
+int detectedUnitCount = 0;
+int detectedUnitAddresses[UNITS_AMOUNT];
+
+void probeI2cBus() {
+#if SERIAL_ENABLE == false && UNIT_CALLS_DISABLE == false
+  SerialPrintln("Scanning I2C bus for units...");
+  detectedUnitCount = 0;
+  for (int unitIndex = 0; unitIndex < UNITS_AMOUNT; unitIndex++) {
+    int i2cAddress = toI2cAddress(unitIndex);
+    Wire.beginTransmission(i2cAddress);
+    if (Wire.endTransmission() == 0) {
+      detectedUnitAddresses[detectedUnitCount++] = i2cAddress;
+      SerialPrint("- unit responding at 0x");
+      SerialPrintln(String(i2cAddress, HEX));
+    }
+  }
+  SerialPrint("I2C scan complete. Detected ");
+  SerialPrint(detectedUnitCount);
+  SerialPrint("/");
+  SerialPrint(UNITS_AMOUNT);
+  SerialPrintln(" expected units.");
+#endif
 }

--- a/README.md
+++ b/README.md
@@ -139,11 +139,22 @@ A simple sketch has been written to set the offset. Upload the `EEPROM_Write_Off
 
 #### Set Unit Address
 
-Every units address is set by a DIP switch. They need to be set ascending from zero in binary.
-This is how my 10 units are set, 1 means switch is in the up-position:
-| Unit 1 | Unit 2 | Unit 3 | Unit 4 | Unit 5 | Unit 6 | Unit 7 | Unit 8 | Unit 9 | Unit 10 |
-| ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------- |
-| 0000   | 0001   | 0010   | 0011   | 0100   | 0101   | 0110   | 0111   | 1000   | 1001    |
+Every unit's address is set by a DIP switch. Set them ascending from zero in binary — the firmware offsets the DIP value by 1 before calling `Wire.begin()` so the first unit lands on I2C address `0x01` (I2C address `0x00` is the reserved general-call address and cannot be used).
+
+| Unit | DIP  | I2C address |
+| ---- | ---- | ----------- |
+| 1    | 0000 | 0x01        |
+| 2    | 0001 | 0x02        |
+| 3    | 0010 | 0x03        |
+| 4    | 0011 | 0x04        |
+| 5    | 0100 | 0x05        |
+| 6    | 0101 | 0x06        |
+| 7    | 0110 | 0x07        |
+| 8    | 0111 | 0x08        |
+| 9    | 1000 | 0x09        |
+| 10   | 1001 | 0x0A        |
+
+`1` means the switch is in the up position. The master scans the bus at boot and logs which addresses responded (viewable via `pio device monitor` when `SERIAL_ENABLE` is true on the master, or via the `/settings` endpoint).
 
 ### ESP01/ESP8266
 

--- a/Unit/Unit.ino
+++ b/Unit/Unit.ino
@@ -17,6 +17,12 @@
 #define ADRESSSW3 4
 #define ADRESSSW4 3
 
+// I2C address 0x00 is reserved (general call); offset every unit's address so
+// DIP "0000" maps to 0x01 and DIP "1111" maps to 0x10. The master's
+// ESPMaster/ServiceFlapFunctions.ino defines the same constant and must stay
+// in sync.
+#define I2C_ADDRESS_BASE 1
+
 //constants stepper
 #define STEPPERPIN1 11
 #define STEPPERPIN2 10
@@ -230,10 +236,11 @@ void requestEvent() {
   */
 }
 
-//returns the adress of the unit as int from 0-15
+//returns the I2C address of the unit. DIP reads 0-15, offset by I2C_ADDRESS_BASE
+//so we skip the reserved 0x00 general-call address.
 int getaddress() {
-  int address = !digitalRead(ADRESSSW4) + (!digitalRead(ADRESSSW3) * 2) + (!digitalRead(ADRESSSW2) * 4) + (!digitalRead(ADRESSSW1) * 8);
-  return address;
+  int dipValue = !digitalRead(ADRESSSW4) + (!digitalRead(ADRESSSW3) * 2) + (!digitalRead(ADRESSSW2) * 4) + (!digitalRead(ADRESSSW1) * 8);
+  return I2C_ADDRESS_BASE + dipValue;
 }
 
 //gets magnet sensor offset from EEPROM in steps


### PR DESCRIPTION
Closes #7, closes #8.

## Root cause

DIP \"0000\" mapped to I2C address 0x00, which is the reserved general-call address. First unit never responded — the I2C bug users have been running into out of the box.

## Fix

- Both sides offset by `I2C_ADDRESS_BASE = 1` so DIP 0000 → I2C 0x01, DIP 1111 → 0x10.
- Master gets a `toI2cAddress(unitIndex)` helper; unit's `getaddress()` adds the offset before `Wire.begin()`.
- Same constant defined on both sides with cross-reference comments (no shared header between the two sketches).
- README DIP table updated with the I2C address column.

## Bus probe

- `probeI2cBus()` runs once at boot, logs responders, populates `detectedUnitCount` + `detectedUnitAddresses[]`.
- Exposed in `/settings` JSON. UI can warn on a mismatch (follow-up, not in this PR).

## Verified locally

- \`pio run -e espmaster\` clean
- \`pio run -e unit\` clean
- \`pio test -e native\` — 14/14

## Test plan

- [ ] Flash master + all units, open serial monitor briefly (master runs SERIAL_ENABLE=false so you need a NodeMCU for this, or check /settings JSON instead)
- [ ] Confirm /settings JSON reports \`detectedUnitCount\` matching the physical units
- [ ] Confirm first unit (previously silent) now responds to text updates

## Not in this PR

Web-UI warning banner, address change from UI, interactive positioning/calibration — these are follow-up scope.