### PR TITLE
Show master-side logs in the web UI

### DIFF
--- a/ESPMaster/ESPMaster.ino
+++ b/ESPMaster/ESPMaster.ino
@@ -312,6 +312,12 @@ void setup() {
       SerialPrintln("Request for Health Check Received");
       request->send(200, "text/plain", "Healthy");
     });
+
+    webServer.on("/log", HTTP_GET, [](AsyncWebServerRequest * request) {
+      //Don't SerialPrintln here; every log request would otherwise stamp
+      //itself into the buffer on every poll and drown out real activity.
+      request->send(200, "text/plain", webLogRead());
+    });
     
     webServer.on("/reboot", HTTP_GET, [](AsyncWebServerRequest * request) {
       SerialPrintln("Request to Reboot Received");

--- a/ESPMaster/HelpersSerialHandling.h
+++ b/ESPMaster/HelpersSerialHandling.h
@@ -1,15 +1,27 @@
 #pragma once
 
 #include <Arduino.h>
+#ifndef UNIT_TEST
+#include "WebLog.h"
+#endif
 
 // Centralised serial output so each call site doesn't need its own
 // `#if SERIAL_ENABLE` guard. Templates live in a header because the
 // Arduino sketch preprocessor can't auto-prototype templates correctly.
+//
+// Output is also mirrored to the in-RAM web log ring buffer (exposed at
+// GET /log) so you can see firmware activity from the UI without needing
+// a USB-serial connection. The web-log tap runs regardless of
+// SERIAL_ENABLE; it's skipped in the native test environment so the
+// sketch logic stays linkable there.
 
 template <typename T>
 void SerialPrint(T value) {
 #if SERIAL_ENABLE == true
   Serial.print(value);
+#endif
+#ifndef UNIT_TEST
+  webLogPrinter.print(value);
 #endif
 }
 
@@ -18,11 +30,21 @@ void SerialPrintf(const char* message, T value) {
 #if SERIAL_ENABLE == true
   Serial.printf(message, value);
 #endif
+#ifndef UNIT_TEST
+  char buf[96];
+  int n = snprintf(buf, sizeof(buf), message, value);
+  if (n > 0) {
+    webLogAppend(buf, n > (int)sizeof(buf) - 1 ? (int)sizeof(buf) - 1 : n);
+  }
+#endif
 }
 
 template <typename T>
 void SerialPrintln(T value) {
 #if SERIAL_ENABLE == true
   Serial.println(value);
+#endif
+#ifndef UNIT_TEST
+  webLogPrinter.println(value);
 #endif
 }

--- a/ESPMaster/ServiceWebLog.ino
+++ b/ESPMaster/ServiceWebLog.ino
@@ -1,0 +1,72 @@
+#include "WebLog.h"
+
+#ifndef WEBLOG_DISABLE
+
+// Byte-oriented ring buffer. We capture raw output rather than framed lines
+// so the SerialPrint / SerialPrintf / SerialPrintln helpers don't need to
+// agree on where a line ends; what readers see is simply the last WEBLOG_SIZE
+// bytes of serial-style output, newlines intact.
+
+static char webLogBuffer[WEBLOG_SIZE];
+static size_t webLogHead = 0;
+static bool webLogWrapped = false;
+
+WebLogPrinter webLogPrinter;
+
+size_t WebLogPrinter::write(uint8_t b) {
+  webLogAppend((const char*)&b, 1);
+  return 1;
+}
+
+size_t WebLogPrinter::write(const uint8_t* buffer, size_t size) {
+  webLogAppend((const char*)buffer, size);
+  return size;
+}
+
+void webLogAppend(const char* data, size_t len) {
+  if (data == nullptr || len == 0) return;
+
+  // The Wire library runs under interrupts on the ESP8266; protect the
+  // shared pointer state even though the body is short.
+  noInterrupts();
+  for (size_t i = 0; i < len; i++) {
+    webLogBuffer[webLogHead] = data[i];
+    webLogHead++;
+    if (webLogHead >= WEBLOG_SIZE) {
+      webLogHead = 0;
+      webLogWrapped = true;
+    }
+  }
+  interrupts();
+}
+
+String webLogRead() {
+  String out;
+
+  noInterrupts();
+  size_t head = webLogHead;
+  bool wrapped = webLogWrapped;
+  interrupts();
+
+  if (wrapped) {
+    out.reserve(WEBLOG_SIZE + 1);
+    // Oldest slice lives from `head` to end of buffer; newest from 0 to `head`.
+    for (size_t i = head; i < WEBLOG_SIZE; i++) out += webLogBuffer[i];
+    for (size_t i = 0; i < head; i++)           out += webLogBuffer[i];
+  } else {
+    out.reserve(head + 1);
+    for (size_t i = 0; i < head; i++)           out += webLogBuffer[i];
+  }
+
+  return out;
+}
+
+#else
+
+WebLogPrinter webLogPrinter;
+size_t WebLogPrinter::write(uint8_t)                     { return 1; }
+size_t WebLogPrinter::write(const uint8_t*, size_t size) { return size; }
+void   webLogAppend(const char*, size_t)                 {}
+String webLogRead() { return String("(web log disabled at build time)"); }
+
+#endif

--- a/ESPMaster/WebLog.h
+++ b/ESPMaster/WebLog.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <Arduino.h>
+#include <Print.h>
+
+// In-RAM ring buffer capturing the tail of every SerialPrint* call on the
+// master. Exposed to the web UI via `GET /log` so you can see what the
+// firmware is doing without needing a USB-serial connection (which in turn
+// would require SERIAL_ENABLE=true, which disables I2C).
+//
+// Capture happens regardless of SERIAL_ENABLE. Disable the whole feature
+// with `-D WEBLOG_DISABLE` if RAM pressure ever forces the issue.
+
+#ifndef WEBLOG_SIZE
+#define WEBLOG_SIZE 4096
+#endif
+
+// `webLogPrinter` is a Print-derived sink so every type Serial can format
+// (int, float, String, IPAddress, Printable, etc.) works out of the box
+// without a pile of template overloads in the SerialPrint helpers.
+class WebLogPrinter : public Print {
+public:
+  size_t write(uint8_t b) override;
+  size_t write(const uint8_t* buffer, size_t size) override;
+};
+
+extern WebLogPrinter webLogPrinter;
+
+void webLogAppend(const char* data, size_t len);
+String webLogRead();

--- a/ESPMaster/data/index.html
+++ b/ESPMaster/data/index.html
@@ -159,6 +159,15 @@
 					</div>
 				</div>
 			</form>
+
+			<div class="card-grid">
+				<div class="card card-full">
+					<details id="logDetails">
+						<summary class="card-title">Log</summary>
+						<pre id="logContent" class="log-pane"></pre>
+					</details>
+				</div>
+			</div>
 		</div>
 	</div>
 	<script src="script.js" /></script>

--- a/ESPMaster/data/script.js
+++ b/ESPMaster/data/script.js
@@ -410,4 +410,55 @@ function showContent() {
 
 	elementInitialLoading.classList.add("hidden");
 	elementContent.classList.remove("hidden");
+
+	initLogPanel();
+}
+
+//Log panel: polls GET /log every 2s while the <details> is open.
+function initLogPanel() {
+	var details = document.getElementById("logDetails");
+	var pre = document.getElementById("logContent");
+	if (!details || !pre) return;
+
+	var pollHandle = null;
+
+	function fetchLog() {
+		fetch('/log', { cache: 'no-store' })
+			.then(function (r) { return r.ok ? r.text() : ''; })
+			.then(function (text) {
+				//Preserve scroll-lock-to-bottom UX: if the user was already at the
+				//bottom, stay pinned there as new content arrives.
+				var atBottom = (pre.scrollTop + pre.clientHeight) >= (pre.scrollHeight - 8);
+				pre.textContent = text;
+				if (atBottom) pre.scrollTop = pre.scrollHeight;
+			})
+			.catch(function () { /* network hiccups shouldn't blow up the UI */ });
+	}
+
+	function startPolling() {
+		if (pollHandle !== null) return;
+		fetchLog();
+		pollHandle = setInterval(fetchLog, 2000);
+	}
+
+	function stopPolling() {
+		if (pollHandle === null) return;
+		clearInterval(pollHandle);
+		pollHandle = null;
+	}
+
+	details.addEventListener('toggle', function () {
+		if (details.open) startPolling();
+		else stopPolling();
+	});
+
+	//Also stop polling if the tab is hidden — no point waking the ESP for updates nobody's reading.
+	document.addEventListener('visibilitychange', function () {
+		if (document.hidden) stopPolling();
+		else if (details.open) startPolling();
+	});
+
+	if (localDevelopment) {
+		pre.textContent = "Starting Split-Flap...\nScanning I2C bus for units...\n- unit responding at 0x01\n- unit responding at 0x02\nI2C scan complete. Detected 2/10 expected units.\n";
+	}
 }

--- a/ESPMaster/data/style.css
+++ b/ESPMaster/data/style.css
@@ -339,4 +339,39 @@ input[type=datetime-local] {
 	  height: 32px;
 	}
   }
+
+#logDetails summary {
+	cursor: pointer;
+	list-style: none;
+}
+
+#logDetails summary::-webkit-details-marker {
+	display: none;
+}
+
+#logDetails summary::before {
+	content: "▶ ";
+	display: inline-block;
+	transition: transform 0.2s;
+}
+
+#logDetails[open] summary::before {
+	transform: rotate(90deg);
+}
+
+.log-pane {
+	background: #111;
+	color: #ddd;
+	font-family: ui-monospace, Menlo, Consolas, monospace;
+	font-size: 0.85rem;
+	line-height: 1.3;
+	text-align: left;
+	padding: 0.8em 1em;
+	margin: 0.5em 0 0 0;
+	max-height: 360px;
+	overflow: auto;
+	white-space: pre-wrap;
+	word-break: break-word;
+	border-radius: 4px;
+}
   


### PR DESCRIPTION
Closes #13. Independent of the bootloader PRs — can merge before or after #12.

## Summary

- 4 KB ring buffer on the master captures every \`SerialPrint*\` call, regardless of \`SERIAL_ENABLE\`.
- \`GET /log\` returns the buffer as \`text/plain\`.
- Collapsible "Log" card on the main page polls \`/log\` every 2 s while open. Stops polling when collapsed or when the tab loses focus.
- Auto-scrolls to bottom when new content arrives, *but only if the user was already at the bottom* — scrolling up to read older lines doesn't get hijacked.

## Implementation note

Rather than an overload-per-type set, the ring buffer is fronted by a \`WebLogPrinter\` that derives from Arduino's \`Print\`. Every type \`Serial.print(x)\` already handles (int, float, String, \`IPAddress\`, \`Printable\`, …) works automatically.

The \`/log\` endpoint deliberately doesn't log its own requests — otherwise every poll would write itself into the buffer and drown out real activity.

## Cost

- Flash: +5 KB (~0.7 %).
- RAM: +9 % (45 % → 54 % of 82 KB on the ESP-01). 4 KB is the ring buffer, rest is \`Print\` virtual table / \`String\` overhead.
- Disable with \`-D WEBLOG_DISABLE\` if RAM pressure bites.

## Test plan

- [x] \`pio run -e espmaster\` clean
- [x] \`pio test -e native\` — 14/14
- [ ] Flash to hardware, confirm /log shows "Scanning I2C bus…" + probe results from boot
- [ ] Confirm polling pauses when the Log section is collapsed (watch network tab)
- [ ] Confirm /log itself doesn't appear in its own output