### PR TITLE
Stop button + rate-limit display wait-loop log spam

### DIFF
--- a/ESPMaster/ESPMaster.h
+++ b/ESPMaster/ESPMaster.h
@@ -37,6 +37,9 @@ int  homeUnit(int i2cAddress);
 // flash is active. flashUnitFromProgmem() is the only caller of the
 // begin/finish helpers now that the HEX upload path is gone.
 extern volatile bool firmwareFlashInProgress;
+// Abort flag for the showMessage wait loop. Set by POST /stop, consumed
+// (and cleared) by showMessage(). Defined in ESPMaster.ino. Issue #35.
+extern volatile bool abortCurrentShow;
 bool beginFirmwareFlash(uint8_t i2cAddress, String& error);
 bool finishFirmwareFlash(String& resultMsg);
 void abortFirmwareFlash(const String& reason);

--- a/ESPMaster/ESPMaster.ino
+++ b/ESPMaster/ESPMaster.ino
@@ -195,6 +195,12 @@ bool alignmentUpdated = false;
 bool isPendingReboot = false;
 bool isPendingUnitsReset = false;
 bool isWifiConfigured = false;
+
+//Set by POST /stop to break out of the wait loop inside showMessage() when
+//a unit gets physically stuck and its status byte pegs at "rotating"
+//forever. Checked every ~100 ms; cleared at the start of each new
+//showMessage. Issue #35.
+volatile bool abortCurrentShow = false;
 std::vector<ScheduledMessage> scheduledMessages;
 
 //Create AsyncWebServer object on port 80
@@ -583,6 +589,35 @@ void setup() {
         return;
       }
       request->send(200, "text/plain", "Home requested");
+    });
+
+    //POST /stop — user-visible kill-switch (issue #35). Aborts any running
+    //showMessage() wait loop, sends CMD_HOME to every detected sketch-
+    //running unit (so every drum parks at blank), and clears the in-memory
+    //text so the event loop doesn't immediately re-send the previous
+    //message. Safe to call when nothing is happening; it's idempotent.
+    webServer.on("/stop", HTTP_POST, [](AsyncWebServerRequest * request) {
+      if (firmwareFlashInProgress) {
+        request->send(503, "text/plain", "Unit firmware flash in progress — try again in a moment");
+        return;
+      }
+      SerialPrintln("Request to Stop Received");
+      abortCurrentShow = true;
+      int homed = 0;
+      for (int unitIndex = 0; unitIndex < UNITS_AMOUNT; unitIndex++) {
+        if (detectedUnitStates[unitIndex] != 1) continue;
+        int addr = unitIndex + 1;  // I2C_ADDRESS_BASE == 1, defined in ServiceFlapFunctions.ino
+        if (homeUnit(addr) == 0) homed++;
+      }
+      //Prevent the event loop from re-issuing showText() with the previous
+      //content. Clearing both inputText and lastWrittenText makes the
+      //showText("" vs "") comparison a no-op.
+      inputText = "";
+      lastWrittenText = "";
+      String body = "Stop requested; homed ";
+      body += homed;
+      body += " unit(s).";
+      request->send(200, "text/plain", body);
     });
 
     //GET /reflash-units — forces every sketch-running unit into its twiboot

--- a/ESPMaster/ServiceFlapFunctions.ino
+++ b/ESPMaster/ServiceFlapFunctions.ino
@@ -153,11 +153,29 @@ void showMessage(String message, int flapSpeed) {
   SerialPrintln("Unit Calls are disabled for debugging. Will delay to simulate calls...");
   delay(2000);
 #else
-  //Wait while display is still moving
+  //Wait while display is still moving, with a hard timeout so a physically
+  //stuck unit (status byte pegged at 1) doesn't deadlock the event loop.
+  //Rate-limit the log line to once per 5 s — previously this spammed /log
+  //at ~10 Hz. Abortable via /stop (issue #35).
+  abortCurrentShow = false;
   SerialPrintln("Unit calls are enabled. Will display message");
+  unsigned long waitStart = millis();
+  unsigned long lastWaitLog = 0;
   while (isDisplayMoving()) {
-    SerialPrintln("Waiting for display to stop");
-    delay(500);
+    if (abortCurrentShow) {
+      SerialPrintln("Show aborted by user (entry wait)");
+      return;
+    }
+    unsigned long elapsed = millis() - waitStart;
+    if (elapsed > 30000) {
+      SerialPrintln("Wait timed out after 30s — assuming a unit is stuck, continuing anyway");
+      break;
+    }
+    if (millis() - lastWaitLog > 5000) {
+      SerialPrintln("Waiting for display to stop");
+      lastWaitLog = millis();
+    }
+    delay(100);
   }
 
   for (int unitIndex = 0; unitIndex < UNITS_AMOUNT; unitIndex++) {
@@ -185,9 +203,24 @@ void showMessage(String message, int flapSpeed) {
     }
   }
 
-  //Wait for the display to stop moving before exit
+  //Wait for the display to stop moving before exit. Same timeout + rate
+  //limit + abort behavior as the entry wait above.
+  waitStart = millis();
+  lastWaitLog = 0;
   while (isDisplayMoving()) {
-    SerialPrintln("Waiting for display to stop now message is display");
+    if (abortCurrentShow) {
+      SerialPrintln("Show aborted by user (exit wait)");
+      return;
+    }
+    unsigned long elapsed = millis() - waitStart;
+    if (elapsed > 30000) {
+      SerialPrintln("Exit wait timed out after 30s — assuming a unit is stuck, continuing anyway");
+      break;
+    }
+    if (millis() - lastWaitLog > 5000) {
+      SerialPrintln("Waiting for display to stop");
+      lastWaitLog = millis();
+    }
     delay(100);
   }
 #endif
@@ -232,28 +265,27 @@ bool isDisplayMoving() {
     }
     displayState[unitIndex] = checkIfMoving(unitIndex);
     if (displayState[unitIndex] == 1) {
-      SerialPrintln("A unit in the display is busy");
+      //Don't log per-iteration — the caller's rate-limited wait loop
+      //already reports "waiting for display to stop" every 5s. This used
+      //to fire ~10×/s and drowned out everything else (issue #35).
       return true;
     }
   }
 
-  SerialPrintln("Display is standing still");
   return false;
 }
 
-//Checks if single unit is moving (by 0-based unit index).
+//Checks if single unit is moving (by 0-based unit index). Called ~10×/s
+//from isDisplayMoving() — must be quiet on /log when nothing is wrong.
 int checkIfMoving(int unitIndex) {
   int i2cAddress = toI2cAddress(unitIndex);
   int active;
   Wire.requestFrom(i2cAddress, ANSWER_SIZE, 1);
   active = Wire.read();
 
-  SerialPrint(i2cAddress);
-  SerialPrint(":");
-  SerialPrintln(active);
-
   if (active == -1) {
-    SerialPrintln("Try to wake up unit");
+    //Wake-up ping: empty transmission pulses the TWI peripheral. Log once
+    //(the caller throttles its own wait-log), not per iteration.
     Wire.beginTransmission(i2cAddress);
     Wire.endTransmission();
   }

--- a/ESPMaster/data/index.html
+++ b/ESPMaster/data/index.html
@@ -114,6 +114,9 @@
 					<p class="card-title">Actions</p>
 
 					<div class="actions">
+						<a id="linkActionStop" href="#" onclick="return stopDisplay();">
+							Stop
+						</a>
 						<a id="linkActionOtaUpdate" href="/ota" onclick="return confirm('Are you sure you want to put device in OTA mode?')">
 							OTA Update
 						</a>

--- a/ESPMaster/data/script.js
+++ b/ESPMaster/data/script.js
@@ -334,6 +334,27 @@ function showHideOtaUpdateAction(isOtaEnabled) {
 	}
 }
 
+//Aborts the running showMessage wait loop, homes every detected unit, and
+//clears inputText so the master's event loop doesn't re-issue the previous
+//message. Used when a unit gets physically stuck mid-rotation (issue #35).
+function stopDisplay() {
+	if (!confirm("Stop the display? All detected units will re-home to blank and the current message will be cleared.")) {
+		return false;
+	}
+	var xhr = new XMLHttpRequest();
+	xhr.open("POST", "/stop");
+	xhr.onreadystatechange = function() {
+		if (xhr.readyState !== 4) return;
+		if (xhr.status === 200) {
+			showBannerMessage(xhr.responseText, 5000);
+		} else {
+			showBannerMessage("Stop request failed: HTTP " + xhr.status, 5000);
+		}
+	};
+	xhr.send();
+	return false;
+}
+
 //Pushes every detected sketch-running unit into its twiboot bootloader and
 //asks the master to re-flash them from the PROGMEM bundle. Blocks while the
 //master works (I2C flashing is serial); progress lines land in /log.


### PR DESCRIPTION
## Summary
- New **Stop** link in the Actions card + `POST /stop` endpoint. Aborts the running `showMessage` wait loop via a `volatile abortCurrentShow` flag, issues `CMD_HOME` to every detected sketch-running unit, clears `inputText` + `lastWrittenText` so the event loop doesn't immediately re-send the previous message.
- Wait-loop log spam fixed: "Waiting for display to stop" rate-limited to once per 5 s; hard 30 s timeout so a physically stuck unit can't deadlock the main loop.
- Per-iteration per-unit status prints in `checkIfMoving()` silenced (fired 50×/s on a 5-unit display during every rotation and drowned out every other log line). `isDisplayMoving()` no longer logs "A unit in the display is busy" every iteration — the rate-limited caller already reports the wait.

## Test plan
- [ ] Flash, open web UI — Actions card shows new **Stop** link.
- [ ] Trigger a long-running message (e.g. text that moves every drum), click **Stop** mid-rotation → drums re-home to blank, log shows "Show aborted by user".
- [ ] Hold a drum so it can't finish rotating → `/log` shows "Waiting for display to stop" once every ~5 s, then "Wait timed out after 30s" once. No 10×/s flooding.
- [ ] Happy path: normal message submission still completes (no regression on showMessage timing).

Closes #35.