### PR TITLE
Space Saving (closes #40)

### DIFF
--- a/ESPMaster/ESPMaster.ino
+++ b/ESPMaster/ESPMaster.ino
@@ -70,7 +70,6 @@
 #endif
 
 #include <Arduino.h>
-#include <ArduinoJson.h>
 #include <ESPAsyncTCP.h>
 #include <ESPAsyncWebSrv.h>
 #include <ESP8266WiFi.h>
@@ -299,10 +298,10 @@ void registerMasterFirmwareEndpoint() {
         uint32_t freeSpace = ESP.getFreeSketchSpace();
         uint32_t maxSketchSpace = (freeSpace - 0x1000) & 0xFFFFF000;
         size_t contentLen = request->contentLength();
-        SerialPrint("Master OTA starting: "); SerialPrintln(filename);
-        SerialPrint("  freeSketchSpace = "); SerialPrintln(freeSpace);
-        SerialPrint("  maxSketchSpace  = "); SerialPrintln(maxSketchSpace);
-        SerialPrint("  contentLength   = "); SerialPrintln(contentLen);
+        SerialPrint(F("Master OTA starting: ")); SerialPrintln(filename);
+        SerialPrint(F("  freeSketchSpace = ")); SerialPrintln(freeSpace);
+        SerialPrint(F("  maxSketchSpace  = ")); SerialPrintln(maxSketchSpace);
+        SerialPrint(F("  contentLength   = ")); SerialPrintln(contentLen);
 
         if (contentLen > 0 && contentLen > maxSketchSpace) {
           otaRejected = true;
@@ -315,7 +314,7 @@ void registerMasterFirmwareEndpoint() {
 
         Update.runAsync(true);
         if (!Update.begin(maxSketchSpace, U_FLASH)) {
-          SerialPrint("Update.begin failed: ");
+          SerialPrint(F("Update.begin failed: "));
           SerialPrintln(Update.getErrorString());
           return;
         }
@@ -342,37 +341,37 @@ void registerMasterFirmwareEndpoint() {
             Update.end(false);
             return;
           }
-          SerialPrint("MD5 expected: "); SerialPrintln(md5);
+          SerialPrint(F("MD5 expected: ")); SerialPrintln(md5);
         }
-        SerialPrintln("Update.begin ok — streaming chunks");
+        SerialPrintln(F("Update.begin ok — streaming chunks"));
       }
       if (otaRejected) return;
       if (!Update.hasError() && len > 0) {
         size_t written = Update.write(data, len);
         if (written != len) {
-          SerialPrint("Update.write short: wrote "); SerialPrint(written);
-          SerialPrint(" of "); SerialPrint(len);
-          SerialPrint(" — err: "); SerialPrintln(Update.getErrorString());
+          SerialPrint(F("Update.write short: wrote ")); SerialPrint(written);
+          SerialPrint(F(" of ")); SerialPrint(len);
+          SerialPrint(F(" — err: ")); SerialPrintln(Update.getErrorString());
         }
       }
       if (final) {
-        SerialPrint("Final chunk: total "); SerialPrint(index + len); SerialPrintln(" bytes");
+        SerialPrint(F("Final chunk: total ")); SerialPrint(index + len); SerialPrintln(F(" bytes"));
         if (Update.end(true)) {
-          SerialPrint("Master OTA complete, ");
+          SerialPrint(F("Master OTA complete, "));
           SerialPrint(index + len);
-          SerialPrintln(" bytes written");
+          SerialPrintln(F(" bytes written"));
           if (!isRecoveryMode) {
             //Push every sketch-running unit into its twiboot bootloader
             //before we reboot. When the new master comes up and probes
             //the bus it'll find them in bootloader state and auto-flash
             //them from the (possibly updated) PROGMEM bundle.
             int rebooted = enterBootloaderAllDetected(false);
-            SerialPrint("Queued ");
+            SerialPrint(F("Queued "));
             SerialPrint(rebooted);
-            SerialPrintln(" unit(s) for bootloader on next boot");
+            SerialPrintln(F(" unit(s) for bootloader on next boot"));
           }
         } else {
-          SerialPrint("Update.end failed: ");
+          SerialPrint(F("Update.end failed: "));
           SerialPrintln(Update.getErrorString());
         }
       }
@@ -387,7 +386,7 @@ void enterRecoveryMode() {
   WiFi.persistent(false);
   WiFi.mode(WIFI_AP);
   WiFi.softAP("split-flap-recovery");
-  SerialPrint("Recovery SoftAP IP: ");
+  SerialPrint(F("Recovery SoftAP IP: "));
   SerialPrintln(WiFi.softAPIP().toString());
 
   webServer.on("/", HTTP_GET, [](AsyncWebServerRequest * request) {
@@ -407,7 +406,7 @@ void enterRecoveryMode() {
   });
   registerMasterFirmwareEndpoint();
   webServer.begin();
-  SerialPrintln("Recovery web server ready");
+  SerialPrintln(F("Recovery web server ready"));
 }
 
 /* .-----------------------------------------------. */
@@ -431,10 +430,10 @@ void setup() {
   //De-activate I2C if debugging the ESP, otherwise serial does not work
   //Wire.begin(D1, D2); //For NodeMCU testing only SDA=D1 and SCL=D2
 #endif
-  SerialPrintln("");
-  SerialPrintln("#######################################################");
-  SerialPrintln("..............Split Flap Display Starting..............");
-  SerialPrintln("#######################################################");
+  SerialPrintln(F(""));
+  SerialPrintln(F("#######################################################"));
+  SerialPrintln(F("..............Split Flap Display Starting.............."));
+  SerialPrintln(F("#######################################################"));
 
   //Increment the RTC boot counter before anything else can crash. The main
   //loop will clear it again once HEALTHY_BOOT_MS of uptime proves the sketch
@@ -442,14 +441,14 @@ void setup() {
   RtcBootState bootState = readBootStateRtc();
   bootState.bootCounter++;
   writeBootStateRtc(bootState);
-  SerialPrint("RTC boot counter: ");
+  SerialPrint(F("RTC boot counter: "));
   SerialPrintln(bootState.bootCounter);
 
   if (bootState.bootCounter >= RECOVERY_BOOT_THRESHOLD) {
-    SerialPrintln("#######################################################");
-    SerialPrintln("RECOVERY MODE: 3+ consecutive boots without a healthy");
-    SerialPrintln("loop. Bringing up split-flap-recovery SoftAP for reflash.");
-    SerialPrintln("#######################################################");
+    SerialPrintln(F("#######################################################"));
+    SerialPrintln(F("RECOVERY MODE: 3+ consecutive boots without a healthy"));
+    SerialPrintln(F("loop. Bringing up split-flap-recovery SoftAP for reflash."));
+    SerialPrintln(F("#######################################################"));
     isRecoveryMode = true;
     enterRecoveryMode();
     return;
@@ -462,7 +461,7 @@ void setup() {
   //catch old-firmware units that need updating. The 200 ms delay gives the
   //Nanos' TWI hardware time to come up after their reset.
   //See issue #30.
-  SerialPrintln("Early I2C scan (twiboot window)...");
+  SerialPrintln(F("Early I2C scan (twiboot window)..."));
   delay(200);
   probeI2cBus();
   autoInstallFirmwareToBootloaderUnits();
@@ -479,11 +478,11 @@ void setup() {
     const char* ntp = (strlen(timezoneServer) > 0) ? timezoneServer : "pool.ntp.org";
     configTime(tz, ntp);
 
-    SerialPrint("Waiting for NTP sync (tz=");
+    SerialPrint(F("Waiting for NTP sync (tz="));
     SerialPrint(tz);
-    SerialPrint(", server=");
+    SerialPrint(F(", server="));
     SerialPrint(ntp);
-    SerialPrintln(")");
+    SerialPrintln(F(")"));
 
     time_t nowSec = 0;
     for (int i = 0; i < 100 && nowSec < 1000000000L; i++) {
@@ -491,7 +490,7 @@ void setup() {
       nowSec = time(nullptr);
     }
 
-    SerialPrint("Current time: ");
+    SerialPrint(F("Current time: "));
     SerialPrintln(formatDateTime("%Y-%m-%d %H:%M:%S"));
     
     //Load various variables
@@ -502,7 +501,7 @@ void setup() {
     //auto-install has settled. This refreshes /settings with the final
     //post-install state — including firmware versions for newly installed
     //units, which couldn't be queried yet during the first scan.
-    SerialPrintln("Settled I2C scan (post-WiFi)...");
+    SerialPrintln(F("Settled I2C scan (post-WiFi)..."));
     probeI2cBus();
     //autoInstallFirmwareToBootloaderUnits() was already called from the
     //early-boot path — any still-in-bootloader units here are either a)
@@ -518,9 +517,9 @@ void setup() {
 
 #if USE_MULTICAST == true
   if (MDNS.begin(mdnsName)) {
-      SerialPrintln("mDNS responder started");
+      SerialPrintln(F("mDNS responder started"));
     } else {
-      SerialPrintln("Error setting up MDNS responder!");
+      SerialPrintln(F("Error setting up MDNS responder!"));
     }
 #endif
 
@@ -531,7 +530,7 @@ void setup() {
     //Tell the browser to revalidate every navigation so an OTA that
     //swaps the UI doesn't leave stale HTML/JS in the tab cache.
     webServer.on("/", HTTP_GET, [](AsyncWebServerRequest * request) {
-      SerialPrintln("Request Home Page Received");
+      SerialPrintln(F("Request Home Page Received"));
       AsyncWebServerResponse *resp = request->beginResponse_P(200, "text/html", INDEX_HTML_GZ, INDEX_HTML_GZ_LEN);
       resp->addHeader("Content-Encoding", "gzip");
       resp->addHeader("Cache-Control", "no-cache");
@@ -560,7 +559,7 @@ void setup() {
     });
 
     webServer.on("/settings", HTTP_GET, [](AsyncWebServerRequest * request) {
-      SerialPrintln("Request for Settings Received");
+      SerialPrintln(F("Request for Settings Received"));
       
       String json = getCurrentSettingValues();
       request->send(200, "application/json", json);
@@ -568,7 +567,7 @@ void setup() {
     });
     
     webServer.on("/health", HTTP_GET, [](AsyncWebServerRequest * request) {
-      SerialPrintln("Request for Health Check Received");
+      SerialPrintln(F("Request for Health Check Received"));
       request->send(200, "text/plain", "Healthy");
     });
 
@@ -579,7 +578,7 @@ void setup() {
     });
     
     webServer.on("/reboot", HTTP_GET, [](AsyncWebServerRequest * request) {
-      SerialPrintln("Request to Reboot Received");
+      SerialPrintln(F("Request to Reboot Received"));
       
       //Create HTML page to explain the system is rebooting
       IPAddress ip = WiFi.localIP();
@@ -758,7 +757,7 @@ void setup() {
         request->send(503, "text/plain", "Unit firmware flash in progress — try again in a moment");
         return;
       }
-      SerialPrintln("Request to Stop Received");
+      SerialPrintln(F("Request to Stop Received"));
       abortCurrentShow = true;
       int homed = 0;
       for (int unitIndex = 0; unitIndex < UNITS_AMOUNT; unitIndex++) {
@@ -782,7 +781,7 @@ void setup() {
     //OTA that ships a new bundled unit firmware if the chained reboot didn't
     //catch every unit, or to manually refresh units without a master reboot.
     webServer.on("/reflash-units", HTTP_GET, [](AsyncWebServerRequest * request) {
-      SerialPrintln("Request to Reflash Units Received");
+      SerialPrintln(F("Request to Reflash Units Received"));
       int rebooted = enterBootloaderAllDetected(true);
       autoInstallFirmwareToBootloaderUnits();
       String body = String("Requested bootloader entry on ") + rebooted +
@@ -792,7 +791,7 @@ void setup() {
     });
 
     webServer.on("/reset-units", HTTP_GET, [](AsyncWebServerRequest * request) {
-      SerialPrintln("Request to Reset Units Received");
+      SerialPrintln(F("Request to Reset Units Received"));
       
       //This will be picked up in the loop
       isPendingUnitsReset = true;
@@ -801,7 +800,7 @@ void setup() {
     });
 
     webServer.on("/", HTTP_POST, [](AsyncWebServerRequest * request) {
-      SerialPrintln("Request Post of Form Received");
+      SerialPrintln(F("Request Post of Form Received"));
 
       bool submissionError = false;
 
@@ -849,11 +848,11 @@ void setup() {
 
       //If there was an error, report back to check what has been input
       if (submissionError) {
-        SerialPrintln("Finished Processing Request with Error");
+        SerialPrintln(F("Finished Processing Request with Error"));
         request->redirect("/?invalid-submission=true");
       }
       else {
-        SerialPrintln("Finished Processing Request Successfully");
+        SerialPrintln(F("Finished Processing Request Successfully"));
 
         lastReceivedMessageDateTime = formatDateTime("%d %b %y %H:%M:%S");
 
@@ -894,7 +893,7 @@ void setup() {
 
 #if WIFI_USE_DIRECT == false
     webServer.on("/reset-wifi", HTTP_GET, [](AsyncWebServerRequest * request) {
-      SerialPrintln("Request to Reset WiFi Received");
+      SerialPrintln(F("Request to Reset WiFi Received"));
       
       IPAddress ip = WiFi.localIP();
       
@@ -915,18 +914,18 @@ void setup() {
     delay(250);
     webServer.begin();
 
-    SerialPrintln("Split Flap Ready!");
-    SerialPrintln("#######################################################");
+    SerialPrintln(F("Split Flap Ready!"));
+    SerialPrintln(F("#######################################################"));
   }
   else {
     if (isPendingReboot) {
-      SerialPrintln("Reboot is pending to be able to continue device function. Hold please...");
-      SerialPrintln("#######################################################");
+      SerialPrintln(F("Reboot is pending to be able to continue device function. Hold please..."));
+      SerialPrintln(F("#######################################################"));
     }
     else {
-      SerialPrintln("Unable to connect to WiFi... Not starting web server");
-      SerialPrintln("Please hard restart your device to try connect again");
-      SerialPrintln("#######################################################");
+      SerialPrintln(F("Unable to connect to WiFi... Not starting web server"));
+      SerialPrintln(F("Please hard restart your device to try connect again"));
+      SerialPrintln(F("#######################################################"));
     }
   }
 }
@@ -941,8 +940,8 @@ void setup() {
 void loop() {
   //Reboot in here as if we restart within a request handler, no response is returned
   if (isPendingReboot) {
-    SerialPrintln("Rebooting Now... Fairwell!");
-    SerialPrintln("#######################################################");
+    SerialPrintln(F("Rebooting Now... Fairwell!"));
+    SerialPrintln(F("#######################################################"));
     //Longer pause so AsyncWebServer can flush the 200 OK body to the client
     //before the restart yanks the TCP socket (issue #37). 100 ms was enough
     //on localhost but often cost the response on real networks.
@@ -960,7 +959,7 @@ void loop() {
   if (!healthyBootMarked && !isRecoveryMode && millis() >= HEALTHY_BOOT_MS) {
     clearBootCounterRtc();
     healthyBootMarked = true;
-    SerialPrintln("Healthy boot — RTC boot counter cleared");
+    SerialPrintln(F("Healthy boot — RTC boot counter cleared"));
   }
 
   //In recovery mode the AsyncWebServer handles every incoming request; the
@@ -973,7 +972,7 @@ void loop() {
 #if WIFI_USE_DIRECT == false
   //Clear off the WiFi Manager Settings
   if (isPendingWifiReset) {
-    SerialPrintln("Removing WiFi settings");
+    SerialPrintln(F("Removing WiFi settings"));
     wifiManager.resetSettings();
     delay(100);
 
@@ -999,7 +998,7 @@ void loop() {
   }
 
   if (isPendingUnitsReset) {
-    SerialPrintln("Reseting Units now...");
+    SerialPrintln(F("Reseting Units now..."));
 
     //Blank out the message
     String blankOutText1 = createRepeatingString('-');
@@ -1013,7 +1012,7 @@ void loop() {
     //We did a reset!
     isPendingUnitsReset = false;
 
-    SerialPrintln("Done Units Reset!");
+    SerialPrintln(F("Done Units Reset!"));
   }
   
   //Don't touch the I2C bus while a unit firmware flash is in flight — the
@@ -1038,42 +1037,87 @@ void loop() {
   }
 }
 
-//Gets all the currently stored calues from memory in a JSON object
+//Appends a JSON-encoded string literal (including the surrounding quotes)
+//to `out`. Handles the escape sequences that can legitimately appear in
+//user-provided text (quotes, backslashes, control chars). Good enough for
+//the fixed shape of /settings — ArduinoJson would be overkill given we only
+//serialize, never parse.
+static void appendJsonString(String& out, const String& value) {
+  out += '"';
+  for (unsigned int i = 0; i < value.length(); i++) {
+    char c = value[i];
+    switch (c) {
+      case '"':  out += "\\\""; break;
+      case '\\': out += "\\\\"; break;
+      case '\b': out += "\\b";  break;
+      case '\f': out += "\\f";  break;
+      case '\n': out += "\\n";  break;
+      case '\r': out += "\\r";  break;
+      case '\t': out += "\\t";  break;
+      default:
+        if ((unsigned char)c < 0x20) {
+          char buf[8];
+          snprintf(buf, sizeof(buf), "\\u%04x", (unsigned char)c);
+          out += buf;
+        } else {
+          out += c;
+        }
+    }
+  }
+  out += '"';
+}
+
+//Gets all the currently stored values from memory as a JSON string.
+//Hand-rolled to avoid pulling in the ArduinoJson library (~30 KB) for a
+//fixed-shape serializer that never needs to parse (issue #40).
 String getCurrentSettingValues() {
-  JsonDocument document;
+  String out;
+  out.reserve(512);
+  out += '{';
 
-  document["timezoneOffset"] = getTimezoneOffsetMinutes();
-  document["unitCount"] = UNITS_AMOUNT;
-  document["detectedUnitCount"] = detectedUnitCount;
+  out += F("\"timezoneOffset\":");          out += getTimezoneOffsetMinutes();
+  out += F(",\"unitCount\":");              out += UNITS_AMOUNT;
+  out += F(",\"detectedUnitCount\":");      out += detectedUnitCount;
+
+  out += F(",\"detectedUnitAddresses\":[");
   for (int i = 0; i < detectedUnitCount; i++) {
-    document["detectedUnitAddresses"][i] = detectedUnitAddresses[i];
+    if (i) out += ',';
+    out += detectedUnitAddresses[i];
   }
-  // Per-unit firmware version, indexed by unit slot (0..UNITS_AMOUNT-1) so the
-  // UI can show a badge per address even for silent units. See issue #28.
-  for (int i = 0; i < UNITS_AMOUNT; i++) {
-    document["detectedUnitVersionStatus"][i] = detectedUnitVersionStatus[i];
-    document["detectedUnitVersions"][i] = detectedUnitVersions[i];
-  }
-  document["alignment"] = alignment;
-  document["flapSpeed"] = flapSpeed;
-  document["deviceMode"] = deviceMode;
-  document["version"] = espVersion;
-  document["lastTimeReceivedMessageDateTime"] = lastReceivedMessageDateTime;
-  document["lastWrittenText"] = lastWrittenText;
+  out += ']';
 
-  document["otaEnabled"] = false;
-  document["isInOtaMode"] = false;
+  //Per-unit firmware version, indexed by unit slot (0..UNITS_AMOUNT-1) so
+  //the UI can show a badge per address even for silent units (issue #28).
+  out += F(",\"detectedUnitVersionStatus\":[");
+  for (int i = 0; i < UNITS_AMOUNT; i++) {
+    if (i) out += ',';
+    out += detectedUnitVersionStatus[i];
+  }
+  out += F("],\"detectedUnitVersions\":[");
+  for (int i = 0; i < UNITS_AMOUNT; i++) {
+    if (i) out += ',';
+    appendJsonString(out, detectedUnitVersions[i]);
+  }
+  out += ']';
+
+  out += F(",\"alignment\":");                       appendJsonString(out, alignment);
+  out += F(",\"flapSpeed\":");                       appendJsonString(out, flapSpeed);
+  out += F(",\"deviceMode\":");                      appendJsonString(out, deviceMode);
+  out += F(",\"version\":");                         appendJsonString(out, String(espVersion));
+  out += F(",\"lastTimeReceivedMessageDateTime\":"); appendJsonString(out, lastReceivedMessageDateTime);
+  out += F(",\"lastWrittenText\":");                 appendJsonString(out, lastWrittenText);
+
+  out += F(",\"otaEnabled\":false");
+  out += F(",\"isInOtaMode\":false");
 
 #if WIFI_USE_DIRECT == false
-  document["wifiSettingsResettable"] = true;
+  out += F(",\"wifiSettingsResettable\":true");
 #else
-  document["wifiSettingsResettable"] = false;
+  out += F(",\"wifiSettingsResettable\":false");
 #endif
-  
-  String jsonString;
-  serializeJson(document, jsonString);
 
-  return jsonString;
+  out += '}';
+  return out;
 }
 
 //Format the current local time via strftime. Replaces ezTime's

--- a/ESPMaster/ServiceFileSystemFunctions.ino
+++ b/ESPMaster/ServiceFileSystemFunctions.ino
@@ -16,7 +16,7 @@ void initialiseFileSystem() {
   EEPROM.begin(SETTINGS_EEPROM_SIZE);
 
   if (readSettingMagic() != SETTINGS_MAGIC || EEPROM.read(OFF_VERSION) != SETTINGS_VERSION) {
-    SerialPrintln("Settings EEPROM blank/stale — initialising with defaults");
+    SerialPrintln(F("Settings EEPROM blank/stale — initialising with defaults"));
     writeSettingString(OFF_ALIGNMENT,  LEN_ALIGNMENT,  ALIGNMENT_MODE_LEFT);
     writeSettingString(OFF_FLAPSPEED,  LEN_FLAPSPEED,  "80");
     writeSettingString(OFF_DEVICEMODE, LEN_DEVICEMODE, DEVICE_MODE_TEXT);
@@ -24,7 +24,7 @@ void initialiseFileSystem() {
     EEPROM.commit();
   }
 
-  SerialPrintln("Settings EEPROM ready");
+  SerialPrintln(F("Settings EEPROM ready"));
 }
 
 void loadValuesFromFileSystem() {
@@ -32,7 +32,7 @@ void loadValuesFromFileSystem() {
   flapSpeed           = readSettingString(OFF_FLAPSPEED,  LEN_FLAPSPEED);
   deviceMode          = readSettingString(OFF_DEVICEMODE, LEN_DEVICEMODE);
 
-  SerialPrintln("Loaded Settings:");
+  SerialPrintln(F("Loaded Settings:"));
   SerialPrintln("   Alignment: " + alignment);
   SerialPrintln("   Flap Speed: " + flapSpeed);
   SerialPrintln("   Device Mode: " + deviceMode);

--- a/ESPMaster/ServiceFirmwareFunctions.ino
+++ b/ESPMaster/ServiceFirmwareFunctions.ino
@@ -119,7 +119,7 @@ static bool twibootWaitReady(uint16_t timeoutMs) {
 
 // Drains one 128-byte page to twiboot.
 static bool producePageToTwiboot(const uint8_t* page, uint16_t addr) {
-  SerialPrint("Writing page 0x");
+  SerialPrint(F("Writing page 0x"));
   SerialPrintln(String(addr, HEX));
 
   // Make sure twiboot is ready before hitting it with a 132-byte burst.
@@ -153,7 +153,7 @@ bool beginFirmwareFlash(uint8_t i2cAddress, String& error) {
     return false;
   }
 
-  SerialPrint("Firmware flash starting, target 0x");
+  SerialPrint(F("Firmware flash starting, target 0x"));
   SerialPrintln(String(i2cAddress, HEX));
 
   // Our DIP-patched twiboot listens on the unit's own address, so that's
@@ -171,12 +171,12 @@ bool beginFirmwareFlash(uint8_t i2cAddress, String& error) {
       error = String("Unit did not ack enter-bootloader (Wire status ") + rebootStatus + ")";
       return false;
     }
-    SerialPrintln("Sent enter-bootloader opcode; waiting for twiboot");
+    SerialPrintln(F("Sent enter-bootloader opcode; waiting for twiboot"));
 
     // Watchdog reset (~15ms) + twiboot init. 500ms is generous.
     delay(500);
   } else {
-    SerialPrintln("Unit already in bootloader; skipping reboot");
+    SerialPrintln(F("Unit already in bootloader; skipping reboot"));
   }
 
   bool bootloaderLive = false;
@@ -191,14 +191,14 @@ bool beginFirmwareFlash(uint8_t i2cAddress, String& error) {
     error = String("Twiboot not responding on 0x") + String(i2cAddress, HEX);
     return false;
   }
-  SerialPrint("Twiboot responding on 0x");
+  SerialPrint(F("Twiboot responding on 0x"));
   SerialPrintln(String(i2cAddress, HEX));
 
   if (!twibootVerifyChip()) {
     error = flashState.errorMsg;
     return false;
   }
-  SerialPrintln("Chip signature OK (ATmega328P, page=128)");
+  SerialPrintln(F("Chip signature OK (ATmega328P, page=128)"));
 
   flashState.errorMsg          = "";
   flashState.totalBytesWritten = 0;
@@ -244,7 +244,7 @@ bool finishFirmwareFlash(String& resultMsg) {
 }
 
 void abortFirmwareFlash(const String& reason) {
-  SerialPrint("Aborting firmware flash: ");
+  SerialPrint(F("Aborting firmware flash: "));
   SerialPrintln(reason);
   firmwareFlashInProgress = false;
 }
@@ -287,11 +287,11 @@ void autoInstallFirmwareToBootloaderUnits() {
     if (detectedUnitStates[unitIndex] != 2 /* bootloader */) continue;
 
     int i2cAddress = toI2cAddress(unitIndex);
-    SerialPrint("Auto-flashing unit at 0x");
+    SerialPrint(F("Auto-flashing unit at 0x"));
     SerialPrint(String(i2cAddress, HEX));
-    SerialPrint(" from PROGMEM (");
+    SerialPrint(F(" from PROGMEM ("));
     SerialPrint(UNIT_FIRMWARE_BIN_LEN);
-    SerialPrintln(" bytes)");
+    SerialPrintln(F(" bytes)"));
 
     String result;
     bool ok = flashUnitFromProgmem((uint8_t)i2cAddress, result);
@@ -306,9 +306,9 @@ void autoInstallFirmwareToBootloaderUnits() {
   }
 
   if (flashedCount > 0) {
-    SerialPrint("Auto-install complete: ");
+    SerialPrint(F("Auto-install complete: "));
     SerialPrint(flashedCount);
-    SerialPrintln(" unit(s) updated.");
+    SerialPrintln(F(" unit(s) updated."));
   }
 #endif
 }
@@ -332,18 +332,18 @@ void autoUpdateOutdatedUnits() {
     if (detectedUnitStates[unitIndex] != 1) continue;           // skip silent/bootloader
     if (detectedUnitVersionStatus[unitIndex] != 1) continue;    // skip ok/unknown
     int addr = toI2cAddress(unitIndex);
-    SerialPrint("Unit at 0x");
+    SerialPrint(F("Unit at 0x"));
     SerialPrint(String(addr, HEX));
-    SerialPrintln(" is OUTDATED — queuing auto-update");
+    SerialPrintln(F(" is OUTDATED — queuing auto-update"));
     if (rebootUnitToBootloader(addr) == 0) {
       queued++;
     }
   }
   if (queued == 0) return;
 
-  SerialPrint("Queued ");
+  SerialPrint(F("Queued "));
   SerialPrint(queued);
-  SerialPrintln(" unit(s) for auto-update; waiting for twiboot");
+  SerialPrintln(F(" unit(s) for auto-update; waiting for twiboot"));
   //Give the Nanos time to reset + twiboot init. 500 ms matches
   //enterBootloaderAllDetected()'s reprobe delay.
   delay(500);

--- a/ESPMaster/ServiceFlapFunctions.ino
+++ b/ESPMaster/ServiceFlapFunctions.ino
@@ -86,20 +86,20 @@ void showText(String message, int delayMillis) {
     String messageDisplay = message == "" ? "<Blank>" : message;
     String alignmentUpdatedDisplay = alignmentUpdated ? "Yes" : "No";
 
-    SerialPrintln("Showing new Message");
+    SerialPrintln(F("Showing new Message"));
     SerialPrintln("New Message: " + messageDisplay);
     SerialPrintln("Alignment Updated: " + alignmentUpdatedDisplay);
   
     std::vector<String> messageLines = processSentenceToLines(message);
 
     if (messageLines.size() > 1) {
-      SerialPrintln("Showing a split down message");
+      SerialPrintln(F("Showing a split down message"));
     
       //Iterate over all the message lines we've got
       for (int linesIndex = 0; linesIndex < messageLines.size(); linesIndex++) {
         String line = messageLines[linesIndex];
 
-        SerialPrint("-- Message Line: ");
+        SerialPrint(F("-- Message Line: "));
         SerialPrintln(line);
 
         showMessage(line, convertSpeed(flapSpeed));
@@ -128,7 +128,7 @@ void showText(String message, int delayMillis) {
     //Alignment definitely has not changed now
     alignmentUpdated = false;
     
-    SerialPrintln("Done showing message");
+    SerialPrintln(F("Done showing message"));
   }
 }
 
@@ -145,12 +145,12 @@ void showMessage(String message, int flapSpeed) {
     message = centerString(message);
   }
 
-  SerialPrint("Showing Aligned Message: \"");
+  SerialPrint(F("Showing Aligned Message: \""));
   SerialPrint(message);
-  SerialPrintln("\"");
+  SerialPrintln(F("\""));
 
 #if UNIT_CALLS_DISABLE == true
-  SerialPrintln("Unit Calls are disabled for debugging. Will delay to simulate calls...");
+  SerialPrintln(F("Unit Calls are disabled for debugging. Will delay to simulate calls..."));
   delay(2000);
 #else
   //Wait while display is still moving, with a hard timeout so a physically
@@ -158,21 +158,21 @@ void showMessage(String message, int flapSpeed) {
   //Rate-limit the log line to once per 5 s — previously this spammed /log
   //at ~10 Hz. Abortable via /stop (issue #35).
   abortCurrentShow = false;
-  SerialPrintln("Unit calls are enabled. Will display message");
+  SerialPrintln(F("Unit calls are enabled. Will display message"));
   unsigned long waitStart = millis();
   unsigned long lastWaitLog = 0;
   while (isDisplayMoving()) {
     if (abortCurrentShow) {
-      SerialPrintln("Show aborted by user (entry wait)");
+      SerialPrintln(F("Show aborted by user (entry wait)"));
       return;
     }
     unsigned long elapsed = millis() - waitStart;
     if (elapsed > 30000) {
-      SerialPrintln("Wait timed out after 30s — assuming a unit is stuck, continuing anyway");
+      SerialPrintln(F("Wait timed out after 30s — assuming a unit is stuck, continuing anyway"));
       break;
     }
     if (millis() - lastWaitLog > 5000) {
-      SerialPrintln("Waiting for display to stop");
+      SerialPrintln(F("Waiting for display to stop"));
       lastWaitLog = millis();
     }
     delay(100);
@@ -190,11 +190,11 @@ void showMessage(String message, int flapSpeed) {
     char currentLetter = message[unitIndex];
     int currentLetterPosition = translateLettertoInt(currentLetter);
 
-    SerialPrint("Unit Nr.: ");
+    SerialPrint(F("Unit Nr.: "));
     SerialPrint(unitIndex);
-    SerialPrint(" Letter: ");
+    SerialPrint(F(" Letter: "));
     SerialPrint(message[unitIndex]);
-    SerialPrint(" Letter position: ");
+    SerialPrint(F(" Letter position: "));
     SerialPrintln(currentLetterPosition);
 
     //only write to unit if char exists in letter array
@@ -209,16 +209,16 @@ void showMessage(String message, int flapSpeed) {
   lastWaitLog = 0;
   while (isDisplayMoving()) {
     if (abortCurrentShow) {
-      SerialPrintln("Show aborted by user (exit wait)");
+      SerialPrintln(F("Show aborted by user (exit wait)"));
       return;
     }
     unsigned long elapsed = millis() - waitStart;
     if (elapsed > 30000) {
-      SerialPrintln("Exit wait timed out after 30s — assuming a unit is stuck, continuing anyway");
+      SerialPrintln(F("Exit wait timed out after 30s — assuming a unit is stuck, continuing anyway"));
       break;
     }
     if (millis() - lastWaitLog > 5000) {
-      SerialPrintln("Waiting for display to stop");
+      SerialPrintln(F("Waiting for display to stop"));
       lastWaitLog = millis();
     }
     delay(100);
@@ -245,7 +245,7 @@ void writeToUnit(int unitIndex, int letter, int flapSpeed) {
 
   //Write values to send to slave in buffer
   for (unsigned int index = 0; index < sizeof sendArray / sizeof sendArray[0]; index++) {
-    SerialPrint("sendArray: ");
+    SerialPrint(F("sendArray: "));
     SerialPrintln(sendArray[index]);
 
     Wire.write(sendArray[index]);
@@ -361,7 +361,7 @@ bool isUnitInBootloader(int i2cAddress) {
 
 void probeI2cBus() {
 #if SERIAL_ENABLE == false && UNIT_CALLS_DISABLE == false
-  SerialPrintln("Scanning I2C bus for units...");
+  SerialPrintln(F("Scanning I2C bus for units..."));
   detectedUnitCount = 0;
   for (int unitIndex = 0; unitIndex < UNITS_AMOUNT; unitIndex++) {
     detectedUnitStates[unitIndex] = 0;  // silent by default
@@ -375,13 +375,13 @@ void probeI2cBus() {
     detectedUnitStates[unitIndex] = inBootloader ? 2 : 1;
     detectedUnitAddresses[detectedUnitCount++] = i2cAddress;
 
-    SerialPrint("- unit at 0x");
+    SerialPrint(F("- unit at 0x"));
     SerialPrint(String(i2cAddress, HEX));
     if (inBootloader) {
-      SerialPrintln(" is in BOOTLOADER mode");
+      SerialPrintln(F(" is in BOOTLOADER mode"));
       continue;
     }
-    SerialPrint(" is running sketch");
+    SerialPrint(F(" is running sketch"));
 
     // Compare against the bundled unit firmware's rev (BUNDLED_UNIT_REV),
     // NOT the master's own GIT_REV. Because unit-firmware.hex is checked in,
@@ -396,16 +396,16 @@ void probeI2cBus() {
       detectedUnitVersionStatus[unitIndex] = match ? 0 : 1;
       SerialPrint(match ? " (fw " : " (fw OUTDATED ");
       SerialPrint(detectedUnitVersions[unitIndex]);
-      SerialPrintln(")");
+      SerialPrintln(F(")"));
     } else {
       detectedUnitVersionStatus[unitIndex] = 2;
-      SerialPrintln(" (fw UNKNOWN — likely predates version opcode)");
+      SerialPrintln(F(" (fw UNKNOWN — likely predates version opcode)"));
     }
   }
-  SerialPrint("I2C scan complete. Detected ");
+  SerialPrint(F("I2C scan complete. Detected "));
   SerialPrint(detectedUnitCount);
-  SerialPrint("/");
+  SerialPrint(F("/"));
   SerialPrint(UNITS_AMOUNT);
-  SerialPrintln(" expected units.");
+  SerialPrintln(F(" expected units."));
 #endif
 }

--- a/ESPMaster/ServiceWifiFunctions.ino
+++ b/ESPMaster/ServiceWifiFunctions.ino
@@ -5,11 +5,11 @@ void initWiFi() {
   WiFi.mode(WIFI_STA);
 
 #if WIFI_USE_DIRECT == false
-  SerialPrintln("Setting up WiFi AP Setup Mode");
+  SerialPrintln(F("Setting up WiFi AP Setup Mode"));
 
 #if WIFI_STATIC_IP == true
   wifiManager.setSTAStaticIPConfig(wifiDeviceStaticIp, wifiRouterGateway, wifiSubnet, wifiPrimaryDns);
-  SerialPrintln("WiFi Static IP Configured");
+  SerialPrintln(F("WiFi Static IP Configured"));
 #endif
 
   //ESPAsyncWiFiManager exposes a subset of tzapu's config API; the rest
@@ -23,35 +23,35 @@ void initWiFi() {
     //Reboot after the portal saves new credentials so the async server
     //can rebind cleanly to the STA interface. Historical note: tzapu's
     //sync portal had a similar gotcha (issues/1579).
-    SerialPrintln("New WiFi configuration saved. Will need to reboot device to let webserver work...");
+    SerialPrintln(F("New WiFi configuration saved. Will need to reboot device to let webserver work..."));
     isPendingReboot = true;
   });
 
-  SerialPrintln("Attempting to connect to WiFi... Will fallback to AP mode to allow configuring of WiFi if fails...");
+  SerialPrintln(F("Attempting to connect to WiFi... Will fallback to AP mode to allow configuring of WiFi if fails..."));
   if(wifiManager.autoConnect("Split-Flap-AP")) {
-    SerialPrint("Successfully Connected to WiFi. IP Address: ");
+    SerialPrint(F("Successfully Connected to WiFi. IP Address: "));
     SerialPrintln(WiFi.localIP());
 
     isWifiConfigured = true;
   }
   
 #else
-  SerialPrintln("Setting up WiFi Direct");
+  SerialPrintln(F("Setting up WiFi Direct"));
 
   if (strlen(wifiDirectSsid) > 0 && strlen(wifiDirectPassword) > 0) {
     int maxAttemptsCount = 0;
     
 #if WIFI_STATIC_IP == true
     if (WiFi.config(wifiDeviceStaticIp, wifiRouterGateway, wifiSubnet, wifiPrimaryDns)) {
-      SerialPrintln("WiFi Static IP Configuration Success");
+      SerialPrintln(F("WiFi Static IP Configuration Success"));
     }
     else {
-      SerialPrintln("WiFi Static IP Configuration could not take place");
+      SerialPrintln(F("WiFi Static IP Configuration could not take place"));
     }
 #endif
     
     WiFi.begin(wifiDirectSsid, wifiDirectPassword);
-    SerialPrint("Connecting");
+    SerialPrint(F("Connecting"));
 
     while (WiFi.status() != WL_CONNECTED && maxAttemptsCount != wifiConnectTimeoutSeconds) {
       if (maxAttemptsCount % 10 == 0) {
@@ -68,7 +68,7 @@ void initWiFi() {
 
     //If we reached the max timeout
     if (maxAttemptsCount != wifiConnectTimeoutSeconds) {
-      SerialPrint("Successfully Connected to WiFi. IP Address: ");
+      SerialPrint(F("Successfully Connected to WiFi. IP Address: "));
       SerialPrintln(WiFi.localIP());
 
       isWifiConfigured = true;

--- a/ESPMaster/platformio.ini
+++ b/ESPMaster/platformio.ini
@@ -29,7 +29,6 @@ build_flags =
   ; the Wire buffer to 256 for enough headroom.
   -DI2C_BUFFER_LENGTH=256
 lib_deps =
-  bblanchon/ArduinoJson@7.4.3
   https://github.com/dvarrel/ESPAsyncTCP.git#1.2.4
   https://github.com/dvarrel/ESPAsyncWebSrv.git#1.2.9
   https://github.com/alanswx/ESPAsyncWiFiManager.git


### PR DESCRIPTION
## Summary

Stacked on top of #39. Two orthogonal wins:

- **Drop ArduinoJson** — `/settings` is a fixed-shape serializer (never parses), so a hand-rolled JSON writer with proper string escaping replaces the library. `~4.7 KB` flash.
- **F() every log literal** — on ESP8266, plain `"literals"` live in DRAM, not flash; wrapping them in `F()` moves them to flash. `~2.6 KB` RAM.

### Size delta (ESP-01 `espmaster` env)

| Baseline | Flash | RAM |
|---|---|---|
| master (pre-#37/#38) | ~443 KB | — |
| after #37/#38 (PR #39) | 372,757 B | 42,708 B |
| **this PR** | **368,305 B** | **39,740 B** |

So cumulatively since master: **~85 KB flash freed** and 3 KB of RAM back.

### LTO attempt

`-flto` broke the ESP8266 newlib link (`_malloc_r`/`_free_r`/`_fstat_r` stripped by the LTO plugin). Kept off. Noted in the commit message so we don't try again without a known workaround.

## Test plan

- [x] `pio run` all three envs (`espmaster`, `unit`, `eeprom_write_offset`)
- [x] `pio test -e native` — 25/25
- [x] `python -m pytest tests/` — 9/9
- [ ] Live web UI load + OTA upload (needs hardware)

## Merge order

This PR targets `fix/37-38-ota-harden-remove-scheduled`. Rebase to master once #39 is merged, or merge #39 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)