### PR TITLE
feat(mqtt): expose detected unit firmware rev per slot in units/attrs (#140)

### DIFF
--- a/firmware/v1/ESPMaster/ServiceFlapFunctions.ino
+++ b/firmware/v1/ESPMaster/ServiceFlapFunctions.ino
@@ -152,10 +152,10 @@ bool readUnitStatus(int i2cAddress, UnitStatus& out) {
 //MQTT json_attributes_topic; faultyUnitCount feeds the integer HA sensor.
 //
 //Sized for the worst case (16 valid units, all counters saturated): ~105 bytes
-//per unit + the ~35-byte wrapper ≈ 1683 bytes. 2048 leaves comfortable headroom
-//(a new per-unit field won't tip a full display into the fail-safe path); the
-//builder's truncation guard degrades to an empty units[] rather than emitting a
-//cut JSON if it ever overruns anyway.
+//per unit + the ~16-byte "rev" field (#140) ≈ 121 bytes/unit + the ~35-byte
+//wrapper ≈ 1971 bytes. 2048 still clears it; the builder's truncation guard
+//degrades to an empty units[] rather than emitting a cut JSON if it ever
+//overruns anyway.
 #define UNIT_HEALTH_JSON_CAP 2048
 UnitStatus unitHealth[UNITS_AMOUNT];
 bool       unitHealthValid[UNITS_AMOUNT];
@@ -191,6 +191,7 @@ void pollUnitHealth() {
   const int width = displayWidth;
   size_t n = buildUnitHealthJson(unitHealthJson, sizeof(unitHealthJson), unitHealth,
                                  unitHealthValid, detectedUnitStates, detectedUnitVersionStatus,
+                                 detectedUnitVersions,
                                  width, faultyUnitCount, I2C_ADDRESS_BASE);
   if (n == 0 || n >= sizeof(unitHealthJson)) {
     //Would-be-truncated payload (device far wider than expected?): fall back to
@@ -520,10 +521,15 @@ static bool readUnitVersion(int i2cAddress, char *out) {
   uint8_t buf[8];
   for (uint8_t i = 0; i < 8; i++) buf[i] = Wire.read();
   // Copy to out, stopping at first null; reject if any non-printable non-null.
+  // Also reject the two JSON-structural characters (" and \): this string is
+  // emitted raw into the unit-health JSON (#140) served over HTTP and MQTT, so
+  // a glitched/unexpected read carrying one of them would break JSON.parse and
+  // Home Assistant's json_attributes. A real git short-rev never contains them.
   uint8_t len = 0;
   for (; len < 8; len++) {
     if (buf[len] == 0) break;
     if (buf[len] < 32 || buf[len] > 126) return false;
+    if (buf[len] == '"' || buf[len] == '\\') return false;
   }
   if (len == 0) return false;
   for (uint8_t i = 0; i < len; i++) out[i] = (char)buf[i];

--- a/firmware/v1/ESPMaster/UnitHealth.h
+++ b/firmware/v1/ESPMaster/UnitHealth.h
@@ -80,6 +80,7 @@ inline int computeFaultyUnitCount(const UnitStatus* health, const bool* valid, i
 // (length >= width). `base` is I2C_ADDRESS_BASE so addr == base + index.
 inline size_t buildUnitHealthJson(char* buf, size_t cap, const UnitStatus* health,
     const bool* valid, const int* states, const int* fwStatus,
+    const char (*versions)[9],
     int width, int faulty, int base) {
   size_t o = 0;
   UNIT_HEALTH_APPEND("{\"width\":%d,\"faulty\":%d,\"units\":[", width, faulty);
@@ -88,8 +89,11 @@ inline size_t buildUnitHealthJson(char* buf, size_t cap, const UnitStatus* healt
                        i == 0 ? "" : ",", i, base + i, states[i], valid[i] ? 1 : 0);
     if (valid[i]) {
       const UnitStatus& s = health[i];
-      UNIT_HEALTH_APPEND(",\"fw\":%d,\"up\":%u,\"br\":%u,\"wd\":%u,\"bc\":%u,\"mc\":%u,\"fl\":%u,\"hs\":%u",
-                         fwStatus[i], (unsigned)s.uptimeSeconds, (unsigned)s.lifetimeBrownoutCount,
+      // #140: emit the master's detected unit rev (8-char git short-rev, NUL-
+      // terminated; empty when the version read failed) so HA/web can see which
+      // firmware a unit is actually on during a reflash-mismatch window.
+      UNIT_HEALTH_APPEND(",\"fw\":%d,\"rev\":\"%s\",\"up\":%u,\"br\":%u,\"wd\":%u,\"bc\":%u,\"mc\":%u,\"fl\":%u,\"hs\":%u",
+                         fwStatus[i], versions[i], (unsigned)s.uptimeSeconds, (unsigned)s.lifetimeBrownoutCount,
                          (unsigned)s.lifetimeWatchdogCount, (unsigned)s.badCommandCount,
                          (unsigned)s.mcusrAtBoot, (unsigned)s.flags, (unsigned)s.lastHomingStepCount);
     }

--- a/firmware/v1/ESPMaster/test/test_unit_health/test_main.cpp
+++ b/firmware/v1/ESPMaster/test/test_unit_health/test_main.cpp
@@ -93,8 +93,9 @@ static void test_json_headline_and_valid_unit_fields() {
   bool valid[2] = { true, true };
   int states[2] = { 1, 1 };
   int fw[2] = { 0, 1 };
+  char versions[2][9] = { "0fd341f", "abc1234" };
   char buf[512];
-  size_t n = buildUnitHealthJson(buf, sizeof(buf), h, valid, states, fw, 2, 1, 1);
+  size_t n = buildUnitHealthJson(buf, sizeof(buf), h, valid, states, fw, versions, 2, 1, 1);
   TEST_ASSERT_TRUE(n > 0 && n < sizeof(buf));
   assert_contains(buf, "\"width\":2");
   assert_contains(buf, "\"faulty\":1");
@@ -104,14 +105,31 @@ static void test_json_headline_and_valid_unit_fields() {
   assert_contains(buf, "\"hs\":720");
   assert_contains(buf, "{\"i\":1,\"a\":2,\"st\":1,\"v\":1");
   assert_contains(buf, "\"br\":4");
+  // #140: detected unit rev string per valid slot.
+  assert_contains(buf, "\"rev\":\"0fd341f\"");
+  assert_contains(buf, "\"rev\":\"abc1234\"");
+}
+static void test_json_invalid_unit_omits_rev() {
+  UnitStatus h[2] = { healthyStatus(), {} };
+  bool valid[2] = { true, false };
+  int states[2] = { 1, 2 };
+  int fw[2] = { 0, 2 };
+  // A stale rev may linger in the slot; an invalid unit must still emit no rev.
+  char versions[2][9] = { "0fd341f", "deadbee" };
+  char buf[512];
+  size_t n = buildUnitHealthJson(buf, sizeof(buf), h, valid, states, fw, versions, 2, 0, 1);
+  TEST_ASSERT_TRUE(n > 0 && n < sizeof(buf));
+  assert_contains(buf, "{\"i\":1,\"a\":2,\"st\":2,\"v\":0}");
+  assert_not_contains(buf, "deadbee");
 }
 static void test_json_invalid_unit_omits_health_fields() {
   UnitStatus h[2] = { healthyStatus(), {} };
   bool valid[2] = { true, false };
   int states[2] = { 1, 2 };   // second slot in bootloader
   int fw[2] = { 0, 2 };
+  char versions[2][9] = { "0fd341f", "" };
   char buf[512];
-  size_t n = buildUnitHealthJson(buf, sizeof(buf), h, valid, states, fw, 2, 0, 1);
+  size_t n = buildUnitHealthJson(buf, sizeof(buf), h, valid, states, fw, versions, 2, 0, 1);
   TEST_ASSERT_TRUE(n > 0 && n < sizeof(buf));
   assert_contains(buf, "{\"i\":1,\"a\":2,\"st\":2,\"v\":0}");
   // The bootloader slot must NOT carry an uptime/fw field.
@@ -120,9 +138,10 @@ static void test_json_invalid_unit_omits_health_fields() {
 static void test_json_truncation_reports_would_be_length() {
   UnitStatus h[4];
   bool valid[4]; int states[4]; int fw[4];
-  for (int i = 0; i < 4; i++) { h[i] = healthyStatus(); valid[i] = true; states[i] = 1; fw[i] = 0; }
+  char versions[4][9];
+  for (int i = 0; i < 4; i++) { h[i] = healthyStatus(); valid[i] = true; states[i] = 1; fw[i] = 0; strcpy(versions[i], "0fd341f"); }
   char small[40];
-  size_t n = buildUnitHealthJson(small, sizeof(small), h, valid, states, fw, 4, 0, 1);
+  size_t n = buildUnitHealthJson(small, sizeof(small), h, valid, states, fw, versions, 4, 0, 1);
   // Guard: signalled overflow via n >= cap, and stayed NUL-terminated inside
   // the buffer (snprintf never runs past `cap`).
   TEST_ASSERT_TRUE(n >= sizeof(small));
@@ -141,6 +160,7 @@ int main(int, char**) {
   RUN_TEST(test_count_ignores_invalid_units);
   RUN_TEST(test_count_zero_when_all_healthy);
   RUN_TEST(test_json_headline_and_valid_unit_fields);
+  RUN_TEST(test_json_invalid_unit_omits_rev);
   RUN_TEST(test_json_invalid_unit_omits_health_fields);
   RUN_TEST(test_json_truncation_reports_would_be_length);
   return UNITY_END();


### PR DESCRIPTION
Closes #140.

## What
Adds `"rev":"<8-char git short-rev>"` per valid slot to the per-unit health JSON built by `buildUnitHealthJson` (UnitHealth.h). The master already reads each unit's rev over I2C (`detectedUnitVersions[i]`) but only published the derived `fw` match/mismatch code — not the actual string.

The rev only diverges from the master-baked `BUNDLED_UNIT_REV` during a **reflash-mismatch window** (units not yet updated, or a failed reflash). That's exactly when you want to know which rev a unit is stuck on, and previously you only got the mismatch flag.

## Where it surfaces
The same JSON serves two consumers, so both get `rev` for free:
- MQTT `units/attrs` json_attributes topic (HA "Faulty units" sensor attributes)
- `GET /units/health` (the #45 web card — receives the field; not yet rendered, easy follow-up)

No HA discovery change needed.

## Safety (from cpp-review)
- `readUnitVersion` now rejects the two JSON-structural chars (`"` and `\`) at the I2C trust boundary — a glitched/unexpected read can't break `JSON.parse` or HA's json_attributes. Real git short-revs never contain them.
- `UNIT_HEALTH_JSON_CAP` (2048) worst case recomputed to ~1971 B for 16 saturated units; truncation guard unchanged (degrades to headline-only JSON on overrun).

## Test plan
- [x] `pio test -e native` — 178/178 pass (2 new: rev present per valid slot, omitted for invalid slots)
- [x] `pio run -e espmaster` — clean, RAM 55.8% / Flash 45.7%
- [ ] Bench: confirm `rev` appears in HA attributes + `GET /units/health` on the 5-unit display

🤖 Generated with [Claude Code](https://claude.com/claude-code)