### PR TITLE
fix(v2): recover the I2C bus after a failed unit read (#207)

### DIFF
--- a/firmware/v2/Master/UnitBus.cpp
+++ b/firmware/v2/Master/UnitBus.cpp
@@ -41,7 +41,22 @@ static int toI2cAddress(int unitIndex) {
 }
 
 void unitBusInit() {
-  Wire.begin(UNIT_BUS_SDA_PIN, UNIT_BUS_SCL_PIN, UNIT_BUS_FREQ_HZ);
+  if (!Wire.begin(UNIT_BUS_SDA_PIN, UNIT_BUS_SCL_PIN, UNIT_BUS_FREQ_HZ)) {
+    SerialPrintln(F("I2C unit bus init failed"));
+  }
+}
+
+// IDF 5.5's esp_driver_i2c only clears its bus-level "transaction contains a
+// read" flag when the read's RX path completes — a failed requestFrom
+// (address NACK from a browned-out unit, timeout on a broken bus) leaves it
+// set, and the next zero-length probe then runs the ISR receive handler
+// against a transaction with no read op: the RX FIFO is copied through a
+// NULL data pointer and the master panics (StoreProhibited, #207). Tearing
+// the bus down and rebuilding it destroys the stale driver state, so every
+// failed read must pass through here before the next probe touches the bus.
+static void recoverBusAfterFailedRead() {
+  Wire.end();
+  unitBusInit();
 }
 
 // Shared opcode-write-then-read-back transaction behind every readUnit*
@@ -58,6 +73,7 @@ static bool queryUnit(int i2cAddress, uint8_t opcode, uint8_t* buf, uint8_t n) {
   uint8_t got = Wire.requestFrom((uint8_t)i2cAddress, n);
   if (got != n) {
     while (Wire.available()) Wire.read();
+    recoverBusAfterFailedRead();
     return false;
   }
   for (uint8_t i = 0; i < n; i++) buf[i] = Wire.read();
@@ -138,6 +154,7 @@ static bool isUnitInBootloader(int i2cAddress) {
   uint8_t got = Wire.requestFrom((uint8_t)i2cAddress, (uint8_t)8);
   if (got < 3) {
     while (Wire.available()) Wire.read();
+    recoverBusAfterFailedRead();
     return false;
   }
   uint8_t sig0 = Wire.read();
@@ -164,6 +181,10 @@ static int checkIfMoving(int unitIndex) {
   Wire.requestFrom((uint8_t)i2cAddress, (uint8_t)1);
   int active = Wire.available() ? Wire.read() : -1;
   if (active == -1) {
+    // The failed read must not leave stale driver state behind (#207): the
+    // wake-up ping below is exactly the probe-after-failed-read shape that
+    // panics the master. Recover first, then ping.
+    recoverBusAfterFailedRead();
     // Wake-up ping: empty transmission pulses the TWI peripheral.
     Wire.beginTransmission(i2cAddress);
     Wire.endTransmission();


### PR DESCRIPTION
Fixes #207.

## Problem

ESP-IDF 5.5.4's `esp_driver_i2c` sets a bus-level `contains_read` flag on every read transaction and clears it **only** when the read's ISR receive path completes (`i2c_master.c:295` / `:776`). A failed `Wire.requestFrom` (address NACK from a browned-out unit, timeout on a floating bus) leaves the flag stale; the next zero-length probe then runs the ISR receive handler against a transaction with no read op, copying the RX FIFO through a NULL data pointer → `StoreProhibited` crash-loop. Reproduced on the bench with nothing on GPIO 8/9 (phantom ACKs → failed reads → panic on the next address probe); the same shape can occur on a live display when a unit dies between a probe and its follow-up read.

## Fix

`recoverBusAfterFailedRead()` in `UnitBus.cpp` (the only Wire toucher): `Wire.end()` + `unitBusInit()`, destroying and recreating the IDF bus handle so the stale driver state cannot survive into the next probe. Called from all three `requestFrom` sites:

- `queryUnit()` (behind every readUnit* helper)
- `isUnitInBootloader()`
- `checkIfMoving()`'s no-reply path — **before** its wake-up ping, which is itself a zero-length probe

Recovery is deliberately unconditional (reviewer flagged the ~10 Hz worst case on a chronically silent unit): each failed read re-arms the stale state, so a once-only debounce would panic on the second poll. The cost is a sub-ms rebuild of a bus that only displayTask touches, bounded by the 30 s stuck-unit cap.

## Verification

- `pio run` (master env): SUCCESS
- `pio test -e native`: 349/349 (UnitBus is hardware glue, not in the native suite — no regressions)
- `python3 -m pytest tests/`: 27/27
- cpp-reviewer gate: approvable as-is, no CRITICAL/HIGH findings

## Bench acceptance (TODO before merge)

- [ ] Boot with nothing on GPIO 8/9: scan may report phantom/zero units, but no Guru Meditation and no wedge
- [ ] Boot with the real 5-unit display: scan, health, text, calibration ops all behave as before