### PR TITLE
chore(v2): retire v1 recovery/quiet-OTA boot-mode remnants

### DIFF
--- a/firmware/v2/Master/DeviceIdentity.h
+++ b/firmware/v2/Master/DeviceIdentity.h
@@ -4,12 +4,12 @@
 // host-side native tests (test/test_device_identity/). The boot-time
 // resolver in ESPMaster.ino reads the EEPROM slot and feeds it through
 // resolveDeviceName(); every network-facing consumer (mDNS, hostname,
-// MQTT client id / topics, recovery / quiet-OTA / captive-portal APs)
-// then reads the single resolved global.
+// MQTT client id / topics, captive-portal AP) then reads the single
+// resolved global.
 //
 // The device name is the COMPLETE identity (not a suffix): "kitchen"
-// yields kitchen.local, hostname kitchen, MQTT id kitchen, recovery AP
-// "kitchen-rec". Empty/invalid/unreadable EEPROM falls back to
+// yields kitchen.local, hostname kitchen, MQTT id kitchen, setup AP
+// "kitchen-setup". Empty/invalid/unreadable EEPROM falls back to
 // "<prefix>-<hex chip id>" which is unique per device and always valid.
 
 #pragma once
@@ -17,18 +17,14 @@
 #include <Arduino.h>
 
 // 24 chars keeps every composed AP SSID inside the 32-byte 802.11 limit
-// given the suffixes below (longest: "-setup", 24 + 6 = 30).
+// given the suffixes composed from the name: "-setup" here (24 + 6 = 30)
+// and the rescue app's "-rescue" (24 + 7 = 31, asserted in its own tree —
+// RescueIdentity.h keeps its own copy of this limit).
 #define DEVICE_NAME_MAX_LEN 24
 
-// AP name suffixes. "-rec" (not "-recovery") so a max-length name still
-// fits: 24 + 9 would be 33 > 32.
-#define AP_SUFFIX_RECOVERY "-rec"
-#define AP_SUFFIX_OTA      "-ota"
-#define AP_SUFFIX_SETUP    "-setup"
+#define AP_SUFFIX_SETUP "-setup"
 
-static_assert(DEVICE_NAME_MAX_LEN + sizeof(AP_SUFFIX_RECOVERY) - 1 <= 32, "recovery SSID would exceed 32 bytes");
-static_assert(DEVICE_NAME_MAX_LEN + sizeof(AP_SUFFIX_OTA) - 1      <= 32, "quiet-OTA SSID would exceed 32 bytes");
-static_assert(DEVICE_NAME_MAX_LEN + sizeof(AP_SUFFIX_SETUP) - 1    <= 32, "captive-portal SSID would exceed 32 bytes");
+static_assert(DEVICE_NAME_MAX_LEN + sizeof(AP_SUFFIX_SETUP) - 1 <= 32, "captive-portal SSID would exceed 32 bytes");
 
 // Lowercase a candidate name. Callers normalize before validating so
 // "Kitchen" just works from the web UI.

--- a/firmware/v2/Master/WebEndpoints.cpp
+++ b/firmware/v2/Master/WebEndpoints.cpp
@@ -940,8 +940,8 @@ void webEndpointsInit(AsyncWebServer& server, MasterSettings& settings,
   // --- v1 endpoints whose services aren't ported yet (#58 slices) ----------
   // Explicit 501s so a bench click yields a clear message instead of a
   // silent 404. Each stub is retired by the slice that ports its service.
-  registerNotPortedStub(server, "/firmware/recover-mark", HTTP_POST);
-  registerNotPortedStub(server, "/firmware/ota-mode", HTTP_POST);
+  // (v1's /firmware/recover-mark and /firmware/ota-mode are retired, not
+  // stubbed: A/B rollback + the rescue app replace those boot modes, #220.)
   registerNotPortedStub(server, "/mqtt/discover", HTTP_GET);
   registerNotPortedStub(server, "/mqtt/discover", HTTP_POST);
 }

--- a/firmware/v2/Master/WifiPolicy.h
+++ b/firmware/v2/Master/WifiPolicy.h
@@ -10,8 +10,7 @@
 //
 // Once Connected the machine is parked for good: link drops belong to the
 // SDK's auto-reconnect (WiFi.setAutoReconnect(true)), never a portal
-// re-entry. Recovery/quiet-OTA boot modes (later #58 slice) branch BEFORE
-// the first step call — those contexts must never open a portal.
+// re-entry.
 
 #include <stdint.h>
 

--- a/firmware/v2/Master/data/index.html
+++ b/firmware/v2/Master/data/index.html
@@ -109,7 +109,7 @@
 							<select id="selectTimezone"></select>
 						</div>
 					</div>
-					<p class="note">Network identity: web address, hostname, Home Assistant id and recovery SSID. Empty = factory default. Applies after a reboot.</p>
+					<p class="note">Network identity: web address, hostname, Home Assistant id and setup/rescue SSIDs. Empty = factory default. Applies after a reboot.</p>
 					<div class="row">
 						<button type="button" class="btn primary" onclick="saveDeviceCard()">Save device</button>
 					</div>

--- a/firmware/v2/Master/data/script.js
+++ b/firmware/v2/Master/data/script.js
@@ -952,8 +952,6 @@ function reflashAllUnits() {
 //Derive "&v=<rev>" for /firmware/master from a build-stamped filename
 //(firmware-<rev>[-dirty]-<size>.bin, see build_assets.py). The rev feeds
 //the boot-time silent-revert check (intendedVersion, #52).
-//KEEP IN SYNC: the same regex is inlined in ServiceBootModes.ino's
-//MINIMAL_UPLOAD_FORM (the recovery/quiet-OTA pages can't load this file).
 function firmwareVersionParam(fileName) {
 	var match = fileName.match(/^firmware-([0-9a-f]{7,40}(?:-dirty)?)(?:-[0-9]+m[0-9]*m?)?\.bin$/i);
 	return match ? "&v=" + encodeURIComponent(match[1]) : "";

--- a/firmware/v2/Master/test/test_device_identity/test_main.cpp
+++ b/firmware/v2/Master/test/test_device_identity/test_main.cpp
@@ -110,9 +110,7 @@ static void test_resolve_falls_back_on_garbage_stored_name() {
 static void test_ap_suffixes_fit_ssid_limit_at_max_name_length() {
   // IEEE 802.11 SSIDs cap at 32 bytes. Every composed AP name must fit
   // even for a maximum-length device name.
-  TEST_ASSERT_TRUE(DEVICE_NAME_MAX_LEN + strlen(AP_SUFFIX_RECOVERY) <= 32);
-  TEST_ASSERT_TRUE(DEVICE_NAME_MAX_LEN + strlen(AP_SUFFIX_OTA)      <= 32);
-  TEST_ASSERT_TRUE(DEVICE_NAME_MAX_LEN + strlen(AP_SUFFIX_SETUP)    <= 32);
+  TEST_ASSERT_TRUE(DEVICE_NAME_MAX_LEN + strlen(AP_SUFFIX_SETUP) <= 32);
 }
 
 int main(int, char**) {


### PR DESCRIPTION
Closes #220.

v1's recovery mode and quiet-OTA mode are ESP8266-era machinery, fully replaced on the S3 by native A/B rollback (#190) and the rescue app (#193/#195). This removes the placeholders instead of letting them answer 501 forever:

- `WebEndpoints.cpp` — `/firmware/recover-mark` + `/firmware/ota-mode` stubs removed (`/mqtt/discover` stubs stay for the MQTT slice)
- `DeviceIdentity.h` — unused `AP_SUFFIX_RECOVERY`/`AP_SUFFIX_OTA` + static_asserts removed; header comment now reflects the real consumers (`-setup` here, `-rescue` asserted in the rescue tree)
- `WifiPolicy.h` — dropped the "recovery/quiet-OTA modes branch before the first step" note (that #58 slice will never exist)
- `data/index.html` — identity note says setup/rescue SSIDs instead of recovery SSID
- `data/script.js` — dropped the stale KEEP-IN-SYNC pointer at v1's `MINIMAL_UPLOAD_FORM`
- `test_device_identity` — suffix-length asserts trimmed to `-setup`

## Test plan
- [x] `pio test -e native` (v2 Master): 375/375 green
- [ ] CI target build (v2 Master compiles with the stub lines removed)