### PR TITLE
chore(v2): bump async web stack — AsyncTCP 3.4.10 + ESPAsyncWebServer 3.11.2

### DIFF
--- a/firmware/v2/Master/platformio.ini
+++ b/firmware/v2/Master/platformio.ini
@@ -89,8 +89,11 @@ extra_scripts =
 lib_deps =
   ; The maintained ESP32 successor of the v1 async stack (the mathieucarbou
   ; fork now lives in the ESP32Async org). v1's dvarrel forks stay ESP8266.
-  esp32async/AsyncTCP@^3.3.2
-  esp32async/ESPAsyncWebServer@^3.7.0
+  ; Floors chosen on #222: AsyncTCP 3.4.6 had a memory leak (fixed 3.4.7),
+  ; ESPAsyncWebServer 3.11.1/.2 carry multipart-parser security fixes that
+  ; matter to POST /firmware/master (and 3.10.1 is a known-bad release).
+  esp32async/AsyncTCP@^3.4.10
+  esp32async/ESPAsyncWebServer@^3.11.2
 build_flags =
   ; Console on the S3's native USB (USB-CDC), not the UART bridge.
   -DARDUINO_USB_MODE=1


### PR DESCRIPTION
Closes #222.

Library-currency audit (2026-07-12): the ESP32Async lineage we pin is still the maintained one, but we were on 3.3.2/3.7.0. New floors resolve to **AsyncTCP 3.4.10 + ESPAsyncWebServer 3.11.2**:

- 3.11.1/3.11.2 fix multipart/boundary parser issues — `POST /firmware/master` is multipart, so these are security-relevant to us
- 3.9.0 made response transmission ~6x faster
- known-bad releases (ESPAsyncWebServer 3.10.1, AsyncTCP 3.4.6 memory leak) sit below the new floors
- only breaking change since 3.7 is WebSocket-related (`CloseClientOnQueueFull` default) — we use no WebSockets

## Test plan
- [x] `pio run` clean build against the new versions (SUCCESS, 2:40)
- [ ] Bench: OTA upload via web UI (multipart path) + general web UI smoke on the devkit