### PR TITLE
feat(cluster): ranked auto-takeover + TWDT crash fix + /coredump (#319 #320 #321)

### DIFF
--- a/docs/superpowers/specs/2026-07-17-cluster-ranked-auto-takeover-design.md
+++ b/docs/superpowers/specs/2026-07-17-cluster-ranked-auto-takeover-design.md
@@ -1,0 +1,145 @@
+# Cluster ranked auto-takeover + takeover-crash fix
+
+**Date:** 2026-07-17
+**Epic:** #270 (multi-display cluster), follows #295 (leader failover 4a shipped, 4b deferred)
+**Status:** design — awaiting review
+
+## Problem
+
+The bench cluster lost its leader (`split-flap-c8a746` @ `.91`) to a hardware/power failure. The wall went dark: the ESP-01 follower (`.121`) blanked after 2 min of silence, and the surviving S3 (`split-flap-a47dee` @ `.20`) did **not** take over, because automatic takeover was deliberately deferred (#295 4b) and the ESP-01 can never promote.
+
+When `.20` was promoted **manually** (`POST /cluster/promote`), it **crashed and rebooted** — confirmed as a **Task Watchdog reset** (`esp_reset_reason()` → `ESP_RST_TASK_WDT`, surfaced live as `"lastResetReason":"Task watchdog"`). The flash log shows `cluster: leading 3 member(s)` immediately followed by a boot banner in the same second. So the manual promote primitive (4a) is not actually reliable — which is exactly the gate the spec required before auto-takeover was allowed.
+
+This design ships three pieces in one spec + PR:
+
+- **Piece 0 — `/coredump` endpoint** — remote crash diagnostics (also used to confirm Piece 1).
+- **Piece 1 — watchdog-safe takeover** — fix the TWDT crash so manual promote is reliable.
+- **Piece 2 — ranked auto-takeover** — leader-designated successor + 30 s rank-staggered self-promotion, with a graceful-reboot "hold" so only a genuinely-gone board triggers a takeover.
+
+The ESP-01 follower is behaviorally **untouched** (it never promotes, never probes, never carries a takeover timer).
+
+---
+
+## Piece 0 — `/coredump` HTTP endpoint
+
+**Purpose.** No USB is available over the VPN, and there is no remote way to read the coredump today (`esp_reset_reason()` gives only the category). Add a small read endpoint that exposes the ESP-IDF coredump for the last panic.
+
+**Surface.**
+- `GET /coredump/summary` → JSON from `esp_core_dump_get_summary()`: crashed task name, PC, and the backtrace address list (+ `GIT_REV` so the addresses can be resolved against the right `firmware.elf`).
+- `GET /coredump/raw` → the raw coredump image (`application/octet-stream`) for `espcoredump.py` offline analysis. Optional; summary is the primary path.
+- Returns `404` when no coredump is present (`esp_core_dump_image_check()` fails).
+
+**Security (important).** A coredump contains live RAM — **HMAC per-member keys and WiFi credentials**. This endpoint is therefore placed on the **closed / same-origin surface**, exactly like `/firmware/*`:
+- NOT added to `clusterCorsPathAllowed` / `followerCorsPathAllowed` (stays off the cluster-open CORS rung).
+- Subject to the same CSRF/Origin rejection as other sensitive routes.
+- S3 (Master) only for now; not ported to the ESP-01 (the ESP-01 has no coredump partition and no serial — out of scope, tracked separately as #316).
+
+**Config check.** Confirm the Master `custom_sdkconfig` has `CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH` + a summary-capable format (ELF). The partition table already reserves `coredump data @ 0x820000 (64 KB)`. If coredump-to-flash is not actually enabled, enable it (guarded by `tests/test_partition_table.py` / a new sdkconfig assertion) — this is a prerequisite for the endpoint to ever return data.
+
+---
+
+## Piece 1 — Watchdog-safe takeover (crash fix)
+
+**Root shape (to be confirmed against the `/coredump/summary` backtrace).** On promote, `clusterPromoteTransform` refills the **dead** leader (`.91`) back into the member table as a plain member, and `applyStagedConfig` resets every per-member runtime to un-joined. The first thing `clusterTask` then does as leader is a **blocking, sequential join fan-out over all members including the dead one** — a 1.5 s `esp_http_client` call to an unreachable host — and the post-promote burst does the whole fan-out in one tick, starving core 0's idle task past the Task Watchdog window.
+
+**Fix.** Make the follower→leader transition watchdog-safe:
+- The post-promote fan-out must obey the same **one-member-per-tick** cadence the steady-state supervisor already uses — the takeover must not synchronously drive the entire join round in a single `clusterTask` iteration.
+- Between per-member network ops in any burst, yield (`vTaskDelay` / feed the TWDT) so idle runs.
+- A dead member during the transition must not block the whole round; it degrades on its own timeout like any other supervised member (existing behavior once we stop bursting).
+
+**Pure-logic seam.** Express "which single member to act on this tick, and when the round is complete" in `ClusterLeaderPolicy.h` (already home to `clusterMemberNextAction`) so it is natively testable — the transition should be a state progression, not a synchronous loop.
+
+**Definition of done (bench drill — the #295 4a gate):** kill the leader, `POST /cluster/promote` on the surviving S3 → it takes over **without resetting** (verify `lastResetReason` stays unchanged across the promote) and re-attaches `.121`. Confirm via `/coredump/summary` that the pre-fix crash was in the takeover path.
+
+---
+
+## Piece 2 — Ranked auto-takeover
+
+Built on the now-reliable promote primitive. Two roles: the leader designates, the S3 followers act.
+
+### Leader side — designate the successor ordering
+
+While leading, the leader computes an ordered list of **eligible successors** and ships it in the ping digest it already sends every tick (#294):
+
+- **Eligible = S3 followers only.** ESP-01s excluded (no promote support). Foreign-platform members excluded (per #297, `clusterMemberPlatForeign`). The leader knows every member's platform from `ClusterMemberRuntime.plat`, so **no `plat` field is added to the digest** — the leader ships the already-filtered result.
+- **Ordering = member-table order** (row/col). Table order *is* the rank. Deterministic, no votes.
+- **Wire:** one additive digest field, an ordered list of member indices, e.g. `succ=2,3`. Followers already store the promote-critical digest table + `you=` self-index in NVS/EEPROM; they now also store `succ`. Absent `succ` (pre-feature leader) ⇒ auto-takeover disabled, manual promote still works (backward compatible).
+
+A follower's **rank** = the position of its own `you=` index within `succ`. Not in `succ` (e.g. an ESP-01) ⇒ rank = none ⇒ never auto-promotes.
+
+### Follower side (S3 only) — rank-staggered self-promotion
+
+A new, independent auto-takeover timer, separate from the display grace/blank timers:
+
+- Constant `CLUSTER_AUTO_TAKEOVER_MS = 30000` (30 s) — the base delay `T`.
+- Constant `CLUSTER_AUTO_TAKEOVER_STAGGER_MS` (e.g. 5 s) — per-rank offset.
+- A board with rank `r` that has been in **LocalFallback** (leader silent, past the standalone/fallback threshold) for `T + r * STAGGER` **and still holds a valid `succ` naming it** self-promotes via the Piece-1 promote path.
+- **Primary (r=0) fires first at 30 s.** If it is alive, it takes over, re-joins every member (fresh HMAC key per member — followers rekey and reset their replay mark on the new-leader join, per #313), their fallback timers clear on the new leader's contact, and **lower-ranked boards never reach their fire time.** Purely time-ordered — no S3→S3 probing, no votes.
+- The existing **sticky-leadership 409** remains the backstop for the rare case where two boards fire near-simultaneously (partition): the loser demotes on contact.
+
+Decision logic is pure in `ClusterFollowerPolicy.h` (`clusterFollowerAutoPromoteDue(state, succList, selfIndex, nowMs)` → bool) with native tests; `ClusterFollower.cpp` calls it from the supervision tick and invokes the existing `clusterFollowerPromote()` when due.
+
+### Graceful-reboot "hold" (load-bearing for 30 s)
+
+At 30 s, a *normal* leader reboot — **including every leader OTA (#305/#276)** and `POST /reboot` — would otherwise look identical to death and trigger a takeover, handing the wall to a unit-less backup while the real leader (with the units) demotes on its sticky-409 return. To prevent this, an **intentional** leader restart announces itself:
+
+- Before an intentional restart (OTA finalize, `/reboot`, reboot-causing config apply), the leader fans out a one-shot **hold hint** to followers — carried on the existing render/ping wire as a `hold=<ms>` field (a bounded value, e.g. ≤ 60 s), HMAC-signed like any leader-wire request.
+- On receipt, a follower extends its auto-takeover deadline by `hold` ms (clamped). This pushes the takeover decision past the reboot window, so **the leader comes back and resumes with no promote/demote churn.**
+- A follower whose leader **vanishes without a hold** hits the plain 30 s path → takeover. This is the "board is just gone" case.
+- The hold **only** suppresses auto-takeover; it does not affect the display grace/blank timers (the wall still holds/blanks on its own schedule).
+
+Pure: `clusterFollowerHoldExtend(state, holdMs, nowMs)` in `ClusterFollowerPolicy.h`, natively tested (including the clamp and that an expired hold reverts to the 30 s rule).
+
+### ESP-01 impact
+
+None behavioral. It is never in `succ`, so it never self-promotes and carries no takeover timer. It already stores the digest; it now stores `succ` and honors `hold` for its **display** grace only if we choose to (optional — the ESP-01 already blanks at 120 s regardless). The pure headers that are copied into the ESP-01 tree (`FollowerPolicy.h`) gain the `succ`/`hold` parsing to keep the twins byte-identical, but the ESP-01's auto-promote path is compiled to a no-op (it has no leader module). Bug-fix-in-both-trees rule applies to the shared pure logic.
+
+---
+
+## Wire changes (summary)
+
+| Field | Direction | Carrier | Meaning | Back-compat |
+|-------|-----------|---------|---------|-------------|
+| `succ=i,j,…` | leader → follower | ping digest | ordered eligible-successor member indices | absent ⇒ auto-takeover off, manual promote unaffected |
+| `hold=<ms>` | leader → follower | render/ping (HMAC-signed) | extend auto-takeover deadline (planned reboot) | absent ⇒ no extension (plain 30 s) |
+
+Both are additive; a pre-feature peer on either end degrades to "manual promote only," never worse than today. No changes to join/leave/render semantics, the HMAC contract, or the IP binding.
+
+---
+
+## Security considerations
+
+- **`/coredump`** is closed-surface / same-origin only (RAM contains keys + creds) — see Piece 0.
+- **`hold` must be HMAC-signed** (it rides the existing signed render/ping), so a spoofed hold can't be injected to *suppress* a legitimate takeover. Bounded/clamped so a malicious large value can't wedge takeover indefinitely.
+- **`succ`** rides the ping digest, which is already signed under #313 (`ping` signs `ts + sha256(digest) + you`); the successor list is inside `digest`, so it is covered — a swapped `succ` breaks the mac.
+- The promoted leader **rekeys every member on takeover** (existing #313 behavior), so a takeover does not weaken the wire-auth posture.
+
+---
+
+## Testing
+
+- **Native (`pio test -e native`)**, both trees where shared: `clusterFollowerAutoPromoteDue` (rank math, staggered fire, `succ` membership), `clusterFollowerHoldExtend` (extend, clamp, expiry), the Piece-1 leader transition state progression.
+- **Wire contract:** `tests/fake_follower.py` / `tests/fake_leader.py` pinned for `succ` + `hold` parse/emit; the ESP-01 fake stays in lockstep with the Master twin.
+- **Bench drills:**
+  1. **Piece 1:** manual promote → no reset (`lastResetReason` unchanged), `.121` re-attaches; `/coredump/summary` confirms the old crash site.
+  2. **Auto-takeover:** pull the leader's power → the designated backup S3 takes the wall within ~30 s, ESP-01 never blanks.
+  3. **Planned reboot:** leader OTA / `/reboot` → **no** takeover, leader resumes, zero promote/demote churn.
+  4. **Two-backup partition:** verify staggered timing means only the primary promotes; sticky-409 resolves the simultaneous edge.
+
+---
+
+## Sequencing / rollout
+
+One branch, one PR, but implemented in dependency order:
+
+1. **Piece 0** `/coredump` → OTA to `.20` → capture the real backtrace.
+2. **Piece 1** watchdog-safe takeover → bench drill 1 (the #295 4a gate) must pass **before** Piece 2 is trusted.
+3. **Piece 2** leader designate + follower staggered promote + graceful hold → bench drills 2–4.
+
+Firmware convergence note: leader and follower must both carry the feature for `succ`/`hold` to matter, but the additive back-compat means a mid-rollout mixed fleet is safe (degrades to manual promote). The #276 rev-mismatch convergence handles bringing the fleet to one build.
+
+## Open items for review
+
+- **Stagger value** (`CLUSTER_AUTO_TAKEOVER_STAGGER_MS`): 5 s proposed — enough that the primary's re-join reaches peers before the secondary fires, small enough that a dead-primary handoff is still quick. Confirm.
+- **Hold trigger points:** OTA finalize + `/reboot` + reboot-causing config apply. Any other intentional restart path to cover?
+- **`/coredump/raw`**: include it, or summary-only for now?

--- a/firmware/v2/Master/ApiIndex.h
+++ b/firmware/v2/Master/ApiIndex.h
@@ -70,7 +70,9 @@ static const ApiRoute API_ROUTES[] = {
   {"GET",  "/cluster/discover",       "cluster mDNS scan result"},
   {"POST", "/cluster/follower-firmware", "store an ESP-01 follower image for relay"},
   {"GET",  "/coredump/summary",       "last-crash task + backtrace (closed surface)"},
-  {"GET",  "/coredump/raw",           "raw ELF coredump for offline analysis"},
+#ifdef COREDUMP_RAW_ENABLE
+  {"GET",  "/coredump/raw",           "raw ELF coredump (opt-in debug build only)"},
+#endif
 };
 static const int API_ROUTES_COUNT = (int)(sizeof(API_ROUTES) / sizeof(API_ROUTES[0]));
 

--- a/firmware/v2/Master/ApiIndex.h
+++ b/firmware/v2/Master/ApiIndex.h
@@ -69,6 +69,8 @@ static const ApiRoute API_ROUTES[] = {
   {"POST", "/cluster/discover",       "start a cluster mDNS scan"},
   {"GET",  "/cluster/discover",       "cluster mDNS scan result"},
   {"POST", "/cluster/follower-firmware", "store an ESP-01 follower image for relay"},
+  {"GET",  "/coredump/summary",       "last-crash task + backtrace (closed surface)"},
+  {"GET",  "/coredump/raw",           "raw ELF coredump for offline analysis"},
 };
 static const int API_ROUTES_COUNT = (int)(sizeof(API_ROUTES) / sizeof(API_ROUTES[0]));
 

--- a/firmware/v2/Master/ClusterDigest.h
+++ b/firmware/v2/Master/ClusterDigest.h
@@ -16,6 +16,7 @@
 #include <Arduino.h>
 
 #include "ClusterLeader.h"
+#include "ClusterRolloutPolicy.h"  // clusterMemberPlatForeign (#321 successors)
 #include "SettingsJson.h"  // appendJsonString
 #include "UnitHealth.h"    // UnitFacts + the faulty predicate
 
@@ -170,6 +171,24 @@ inline String clusterStatusJson(const ClusterLeaderStatus& st) {
 // together they are everything a successor needs. gen bumps only when the
 // content changed (the leader compares digests between builds) so the
 // follower UI can gate re-renders cheaply.
+// #321: the leader's ordered eligible-successor list — the member indices of
+// the S3 followers (in table order) that may take over if the leader dies.
+// Self (empty host) and foreign-platform members (ESP-01, #297) are excluded:
+// only another S3 can promote. Rides the digest so each follower learns its
+// own rank by matching its `you` index against this list.
+inline String clusterSuccessorList(const ClusterLeaderStatus& st) {
+  String out;
+  for (int i = 0; i < st.memberCount; i++) {
+    if (st.members[i].host.length() == 0) continue;  // the leader's own row
+    if (clusterMemberPlatForeign(st.members[i].plat, CLUSTER_LEADER_PLAT)) {
+      continue;  // ESP-01 / foreign board — never a takeover candidate
+    }
+    if (out.length()) out += ',';
+    out += String(i);
+  }
+  return out;
+}
+
 inline String clusterBuildDigest(uint32_t gen, const String& leaderName,
                                  const String& leaderHost,
                                  const String& tableSpec, const String* rows,
@@ -190,7 +209,9 @@ inline String clusterBuildDigest(uint32_t gen, const String& leaderName,
     if (i) out += ',';
     appendJsonString(out, rows[i]);
   }
-  out += "],\"status\":";
+  out += "],\"succ\":";
+  appendJsonString(out, clusterSuccessorList(st));
+  out += ",\"status\":";
   out += clusterStatusJson(st);
   out += '}';
   return out;

--- a/firmware/v2/Master/ClusterDigest.h
+++ b/firmware/v2/Master/ClusterDigest.h
@@ -192,8 +192,8 @@ inline String clusterSuccessorList(const ClusterLeaderStatus& st) {
 inline String clusterBuildDigest(uint32_t gen, const String& leaderName,
                                  const String& leaderHost,
                                  const String& tableSpec, const String* rows,
-                                 int rowCount,
-                                 const ClusterLeaderStatus& st) {
+                                 int rowCount, const ClusterLeaderStatus& st,
+                                 uint32_t holdMs = 0) {
   String out;
   out.reserve(256 + rowCount * 40 + st.memberCount * 200);
   out += "{\"gen\":";
@@ -211,6 +211,8 @@ inline String clusterBuildDigest(uint32_t gen, const String& leaderName,
   }
   out += "],\"succ\":";
   appendJsonString(out, clusterSuccessorList(st));
+  out += ",\"hold\":";
+  out += String((unsigned long)holdMs);  // #321: 0 unless a reboot is imminent
   out += ",\"status\":";
   out += clusterStatusJson(st);
   out += '}';

--- a/firmware/v2/Master/ClusterFollower.cpp
+++ b/firmware/v2/Master/ClusterFollower.cpp
@@ -79,6 +79,10 @@ static bool tableDirty = false;
 // leader hold suppresses takeover. Both live under the ClusterLock.
 static int successorRank = -1;
 static uint32_t autoTakeoverHoldUntilMs = 0;
+// Backoff gate for a FAILED auto-promote (netTask-only): the promote-due inputs
+// don't change on a non-gate failure, so without this the attempt would re-fire
+// every ~10 ms service tick (log spam). 0 = no cooldown pending.
+static uint32_t autoPromoteRetryAtMs = 0;
 
 // Single staged render slot — a newer accepted render simply replaces an
 // undelivered older one (seq acceptance upstream keeps ordering honest).
@@ -147,7 +151,9 @@ void clusterFollowerServiceTick(SettingsStore& store) {
     // under the lock; the promote runs after it releases (it re-locks + takes
     // the leader mutex, and re-checks this gate — TOCTOU-safe).
     doAutoPromote = clusterFollowerAutoPromoteDue(
-        policyState, successorRank, autoTakeoverHoldUntilMs, millis());
+                        policyState, successorRank, autoTakeoverHoldUntilMs,
+                        millis()) &&
+                    (int32_t)(millis() - autoPromoteRetryAtMs) >= 0;
     if (membershipDirty) {
       membershipDirty = false;
       if (leaderHost.length() > 0) {
@@ -232,6 +238,9 @@ void clusterFollowerServiceTick(SettingsStore& store) {
   if (doAutoPromote) {
     ClusterPromoteVerdict v = clusterFollowerPromoteImpl(true);
     if (v.httpStatus != 200) {
+      // Back off so a persistent failure (e.g. no digest held) can't re-fire
+      // every service tick — the promote-due inputs won't change on their own.
+      autoPromoteRetryAtMs = millis() + CLUSTER_AUTO_TAKEOVER_RETRY_MS;
       SerialPrintln(String("cluster: auto-takeover stood down (") + v.message +
                     ")");
     }
@@ -283,6 +292,11 @@ void clusterFollowerHandleJoin(const ClusterJoinRequest& req) {
     hmacLastAcceptedTs = 0;
     hmacLastPersistedTs = 0;
     hmacTsDirty = true;
+    // #321: a new key means a new leader relationship — drop any successor rank
+    // / hold carried over from the previous leader (the new leader's first ping
+    // re-derives them). Correctness-by-construction, not by ping timing.
+    successorRank = -1;
+    autoTakeoverHoldUntilMs = 0;
   }
   // NVS-flood guard (#313): a leader (re)joins on every membership change,
   // but the follower persists only when a field actually moved — a steady

--- a/firmware/v2/Master/ClusterFollower.cpp
+++ b/firmware/v2/Master/ClusterFollower.cpp
@@ -74,6 +74,11 @@ static uint32_t digestReceivedMs = 0;
 static String digestTable;
 static int digestSelfIndex = -1;
 static bool tableDirty = false;
+// #321 ranked auto-takeover: this board's rank in the leader's `succ` list
+// (-1 = not a designated successor), and the deadline until which an announced
+// leader hold suppresses takeover. Both live under the ClusterLock.
+static int successorRank = -1;
+static uint32_t autoTakeoverHoldUntilMs = 0;
 
 // Single staged render slot — a newer accepted render simply replaces an
 // undelivered older one (seq acceptance upstream keeps ordering honest).
@@ -112,11 +117,14 @@ void clusterFollowerInit(SettingsStore& store) {
   }
 }
 
+static ClusterPromoteVerdict clusterFollowerPromoteImpl(bool autoPath);
+
 void clusterFollowerServiceTick(SettingsStore& store) {
   if (clusterMutex == nullptr) return;
 
   bool persistMembership = false;
   bool clearMembership = false;
+  bool doAutoPromote = false;  // #321: decided under the lock, run after it
   String persistName, persistHost;
   int persistRow = 0;
   String persistKeyHex;  // "" = remove the key alongside the membership
@@ -134,6 +142,12 @@ void clusterFollowerServiceTick(SettingsStore& store) {
       SerialPrintln(String("cluster: phase -> ") +
                     clusterFollowerPhaseName(policyState.phase));
     }
+    // #321: a designated successor takes over once leader silence passes its
+    // ranked threshold (fires in Grace, before the wall blanks). Decided here
+    // under the lock; the promote runs after it releases (it re-locks + takes
+    // the leader mutex, and re-checks this gate — TOCTOU-safe).
+    doAutoPromote = clusterFollowerAutoPromoteDue(
+        policyState, successorRank, autoTakeoverHoldUntilMs, millis());
     if (membershipDirty) {
       membershipDirty = false;
       if (leaderHost.length() > 0) {
@@ -209,6 +223,17 @@ void clusterFollowerServiceTick(SettingsStore& store) {
     } else {
       store.remove(CLUSTER_KEY_TABLE);
       store.remove(CLUSTER_KEY_SELF_INDEX);
+    }
+  }
+
+  // #321: run the ranked auto-takeover outside the lock (it re-locks + takes
+  // the leader mutex). The impl re-checks the gate, so a leader that returned
+  // between the decision and here cleanly no-ops the promote.
+  if (doAutoPromote) {
+    ClusterPromoteVerdict v = clusterFollowerPromoteImpl(true);
+    if (v.httpStatus != 200) {
+      SerialPrintln(String("cluster: auto-takeover stood down (") + v.message +
+                    ")");
     }
   }
 }
@@ -314,6 +339,20 @@ bool clusterFollowerHandlePing(const String& digest, int youIndex,
   if (digest.length() > 0 && clusterDigestShapeOk(digest)) {
     digestRaw = digest;
     digestReceivedMs = millis();
+    // #321: refresh our auto-takeover rank from the leader's `succ` list vs our
+    // own `you` index — the leader recomputes it as the fleet changes; -1 means
+    // we're not a designated successor (ESP-01/foreign, or absent) → never fire.
+    successorRank = clusterSuccessorRank(
+        clusterExtractJsonString(digest, "succ").c_str(), youIndex);
+    // #321 graceful-reboot hold: a leader about to restart on purpose stamps a
+    // hold (ms) into its (signed) digest — push our takeover deadline past the
+    // reboot window so a planned reboot doesn't look like death. A swapped/
+    // injected hold can't spoof it: the digest is HMAC-signed above (#313).
+    long holdMs = clusterExtractJsonInt(digest, "hold", 0);
+    if (holdMs > 0) {
+      autoTakeoverHoldUntilMs =
+          clusterAutoTakeoverHoldDeadline((uint32_t)holdMs, millis());
+    }
     // The promote inputs persist only on change — the table moves on
     // config edits, not on the 10 s ping cadence.
     String tableSpec = clusterExtractJsonString(digest, "table");
@@ -369,6 +408,8 @@ static void followerLeaveLocked() {
   digestRaw = "";
   digestTable = "";
   digestSelfIndex = -1;
+  successorRank = -1;          // #321: no longer a successor once we leave
+  autoTakeoverHoldUntilMs = 0;
   tableDirty = true;
   SerialPrintln(F("cluster: left — standalone again"));
 }
@@ -394,14 +435,28 @@ bool clusterFollowerJoinWouldConflict(const String& joiningLeaderHost) {
   return clusterFollowerJoinConflicts(policyState, millis(), sameLeader);
 }
 
-ClusterPromoteVerdict clusterFollowerPromote() {
+// Gate for a promote attempt — MUST be evaluated under the ClusterLock. Manual
+// (#295, web button) requires LocalFallback; auto (#321) requires the ranked
+// takeover trigger (rank + staggered silence, no active hold). The commit-point
+// re-check uses this same gate so a leader returning mid-promote cancels it.
+static bool promoteGatePasses(bool autoPath) {
+  return autoPath ? clusterFollowerAutoPromoteDue(policyState, successorRank,
+                                                  autoTakeoverHoldUntilMs,
+                                                  millis())
+                  : clusterFollowerCanPromote(policyState);
+}
+
+static ClusterPromoteVerdict clusterFollowerPromoteImpl(bool autoPath) {
   if (clusterMutex == nullptr) return {500, "cluster service not running"};
   String tableSpec, oldLeaderHost;
   int selfIndex;
   {
     ClusterLock lock;
-    if (!clusterFollowerCanPromote(policyState)) {
-      return {409, "Promote requires local-fallback — the leader is still expected back"};
+    if (!promoteGatePasses(autoPath)) {
+      return {409, autoPath
+                       ? "auto-takeover not due"
+                       : "Promote requires local-fallback — the leader is "
+                         "still expected back"};
     }
     if (digestTable.length() == 0 || digestSelfIndex < 0) {
       return {409, "No cluster digest held — cannot take over"};
@@ -423,18 +478,24 @@ ClusterPromoteVerdict clusterFollowerPromote() {
   if (v.httpStatus != 200) return {v.httpStatus, v.message};
 
   // Commit point (review HIGH — promote/reclaim TOCTOU): re-check the
-  // phase and leave in ONE critical section. A leader ping landing after
+  // gate and leave in ONE critical section. A leader ping landing after
   // this wins nothing: the board is Standalone (ping 409s) and about to
   // lead; the returning old leader demotes on the sticky-leadership 409s.
   {
     ClusterLock lock;
-    if (!clusterFollowerCanPromote(policyState)) {
-      return {409, "The leader came back — promote cancelled"};
+    if (!promoteGatePasses(autoPath)) {
+      return {409, autoPath ? "auto-takeover cancelled — leader returned"
+                            : "The leader came back — promote cancelled"};
     }
     followerLeaveLocked();
   }
   clusterLeaderStageConfig(newSpec);  // pre-validated: cannot fail
-  SerialPrintln("cluster: PROMOTED — taking over the wall as leader (" +
-                newSpec + ")");
+  SerialPrintln(String("cluster: ") +
+                (autoPath ? "AUTO-PROMOTED" : "PROMOTED") +
+                " — taking over the wall as leader (" + newSpec + ")");
   return {200, "Promoted — leading now; members join on the next tick"};
+}
+
+ClusterPromoteVerdict clusterFollowerPromote() {
+  return clusterFollowerPromoteImpl(false);
 }

--- a/firmware/v2/Master/ClusterFollower.cpp
+++ b/firmware/v2/Master/ClusterFollower.cpp
@@ -237,7 +237,14 @@ void clusterFollowerServiceTick(SettingsStore& store) {
   // between the decision and here cleanly no-ops the promote.
   if (doAutoPromote) {
     ClusterPromoteVerdict v = clusterFollowerPromoteImpl(true);
-    if (v.httpStatus != 200) {
+    if (v.httpStatus == 200) {
+      // Took over. Cool down before we could auto-promote AGAIN: if this was a
+      // false positive (a wedged follower that "lost" a still-alive leader),
+      // the leader sticky-demotes us and we rejoin — this stops that from
+      // becoming a 30 s promote<->demote churn (the cooldown survives the
+      // same-leader rejoin, which doesn't reset it).
+      autoPromoteRetryAtMs = millis() + CLUSTER_AUTO_TAKEOVER_COOLDOWN_MS;
+    } else {
       // Back off so a persistent failure (e.g. no digest held) can't re-fire
       // every service tick — the promote-due inputs won't change on their own.
       autoPromoteRetryAtMs = millis() + CLUSTER_AUTO_TAKEOVER_RETRY_MS;

--- a/firmware/v2/Master/ClusterFollowerPolicy.h
+++ b/firmware/v2/Master/ClusterFollowerPolicy.h
@@ -39,6 +39,8 @@ static const uint32_t CLUSTER_COMMIT_MAX_DELAY_MS = 5000UL;
 // everyone's silence and the lower ranks never fire (deterministic, no votes).
 static const uint32_t CLUSTER_AUTO_TAKEOVER_MS = 30000UL;
 static const uint32_t CLUSTER_AUTO_TAKEOVER_STAGGER_MS = 5000UL;
+// Cooldown after a FAILED auto-promote so it can't re-fire every service tick.
+static const uint32_t CLUSTER_AUTO_TAKEOVER_RETRY_MS = 5000UL;
 // A planned leader restart (OTA/reboot/config) announces a hold so nobody takes
 // over during the reboot window; clamped so a bogus value can't wedge takeover.
 static const uint32_t CLUSTER_AUTO_TAKEOVER_HOLD_MAX_MS = 60000UL;

--- a/firmware/v2/Master/ClusterFollowerPolicy.h
+++ b/firmware/v2/Master/ClusterFollowerPolicy.h
@@ -31,6 +31,18 @@ static const uint32_t CLUSTER_GRACE_MS = 120000UL;
 // synchronized flip — clamp instead of parking the display.
 static const uint32_t CLUSTER_COMMIT_MAX_DELAY_MS = 5000UL;
 
+// Ranked auto-takeover (#321). A designated-successor S3 self-promotes once the
+// leader has been silent this long — 30 s, deliberately EARLIER than the 120 s
+// LocalFallback manual-promote gate, so the backup claims the wall before the
+// ESP-01 rows blank. Lower-ranked successors wait an extra STAGGER each, so the
+// primary (rank 0) always fires first; if it takes over, its re-join clears
+// everyone's silence and the lower ranks never fire (deterministic, no votes).
+static const uint32_t CLUSTER_AUTO_TAKEOVER_MS = 30000UL;
+static const uint32_t CLUSTER_AUTO_TAKEOVER_STAGGER_MS = 5000UL;
+// A planned leader restart (OTA/reboot/config) announces a hold so nobody takes
+// over during the reboot window; clamped so a bogus value can't wedge takeover.
+static const uint32_t CLUSTER_AUTO_TAKEOVER_HOLD_MAX_MS = 60000UL;
+
 enum class ClusterFollowerPhase : uint8_t {
   Standalone = 0,
   Clustered,
@@ -154,6 +166,59 @@ inline bool clusterFollowerJoinConflicts(const ClusterFollowerState& st,
 // (LocalFallback) may take over — Grace still expects the leader back.
 inline bool clusterFollowerCanPromote(const ClusterFollowerState& st) {
   return st.phase == ClusterFollowerPhase::LocalFallback;
+}
+
+// #321: this follower's rank among the leader's ordered eligible-successor list
+// (member indices, e.g. "2,3"), or -1 if it is not a designated successor (an
+// ESP-01, a foreign-plat board, or absent — the leader excludes those). rank 0
+// is the primary successor.
+inline int clusterSuccessorRank(const char* succCsv, int selfIndex) {
+  if (selfIndex < 0 || succCsv == nullptr) return -1;
+  int rank = 0;
+  const char* p = succCsv;
+  while (*p) {
+    if (*p < '0' || *p > '9') {  // comma / any separator
+      p++;
+      continue;
+    }
+    long v = 0;
+    while (*p >= '0' && *p <= '9') {
+      v = v * 10 + (*p - '0');
+      p++;
+    }
+    if (v == selfIndex) return rank;
+    rank++;
+  }
+  return -1;
+}
+
+// #321 ranked auto-takeover trigger. A designated successor (rank >= 0)
+// self-promotes once leader silence reaches the base delay plus its rank
+// stagger — UNLESS a graceful-reboot hold is still suppressing takeover, or
+// the leader is still fresh (Standalone/Clustered). Independent of the manual
+// LocalFallback gate: this fires during Grace, before the wall goes dark.
+inline bool clusterFollowerAutoPromoteDue(const ClusterFollowerState& st,
+                                          int successorRank,
+                                          uint32_t holdUntilMs, uint32_t nowMs) {
+  if (successorRank < 0) return false;
+  if (st.phase == ClusterFollowerPhase::Standalone ||
+      st.phase == ClusterFollowerPhase::Clustered) {
+    return false;  // no membership, or the leader is still in contact
+  }
+  if ((int32_t)(nowMs - holdUntilMs) < 0) return false;  // hold still active
+  uint32_t threshold = CLUSTER_AUTO_TAKEOVER_MS +
+                       (uint32_t)successorRank * CLUSTER_AUTO_TAKEOVER_STAGGER_MS;
+  return (nowMs - st.lastContactMs) >= threshold;
+}
+
+// #321: absolute deadline until which auto-takeover is suppressed, from a
+// leader's announced hold. Clamped so a hostile/bogus hold can't wedge it.
+inline uint32_t clusterAutoTakeoverHoldDeadline(uint32_t holdMs,
+                                                uint32_t nowMs) {
+  if (holdMs > CLUSTER_AUTO_TAKEOVER_HOLD_MAX_MS) {
+    holdMs = CLUSTER_AUTO_TAKEOVER_HOLD_MAX_MS;
+  }
+  return nowMs + holdMs;
 }
 
 // Synchronized flip: ms to wait before enqueueing a render. Unsynced

--- a/firmware/v2/Master/ClusterFollowerPolicy.h
+++ b/firmware/v2/Master/ClusterFollowerPolicy.h
@@ -41,6 +41,11 @@ static const uint32_t CLUSTER_AUTO_TAKEOVER_MS = 30000UL;
 static const uint32_t CLUSTER_AUTO_TAKEOVER_STAGGER_MS = 5000UL;
 // Cooldown after a FAILED auto-promote so it can't re-fire every service tick.
 static const uint32_t CLUSTER_AUTO_TAKEOVER_RETRY_MS = 5000UL;
+// Cooldown after a SUCCESSFUL auto-promote. If it was a false positive (a
+// wedged/flapping follower promoted, then the still-alive leader sticky-demotes
+// it), this stops an immediate re-promote — breaking the promote<->demote churn
+// so the board rejoins and settles instead of thrashing the wall.
+static const uint32_t CLUSTER_AUTO_TAKEOVER_COOLDOWN_MS = 120000UL;
 // A planned leader restart (OTA/reboot/config) announces a hold so nobody takes
 // over during the reboot window; clamped so a bogus value can't wedge takeover.
 static const uint32_t CLUSTER_AUTO_TAKEOVER_HOLD_MAX_MS = 60000UL;

--- a/firmware/v2/Master/ClusterLeader.cpp
+++ b/firmware/v2/Master/ClusterLeader.cpp
@@ -403,9 +403,17 @@ struct MemberWorkItem {
   String body;
 };
 
+// Round-robin cursor for the one-op-per-tick fan-out (#320). clusterTask-
+// private: only collectMemberWork touches it, always under LeaderLock.
+static int fanoutCursor = -1;
+
 // Builds the next round of outbound calls under the lock; the blocking
 // HTTP happens with the mutex RELEASED so submits/status reads never wait
-// on a slow follower.
+// on a slow follower. At most ONE member is contacted per tick (#320): a
+// promote-time catch-up makes every member due at once, and doing them all in
+// one tick — one being a dead host burning the full HTTP timeout — starved
+// core-0 idle past the 5 s task watchdog. clusterFanoutNext round-robins so a
+// stuck dead host can't monopolize the fan-out.
 static int collectMemberWork(MemberWorkItem* items) {
   LeaderLock lock;
   int count = 0;
@@ -413,9 +421,10 @@ static int collectMemberWork(MemberWorkItem* items) {
   // One epoch-ms stamp for every signed request this round (#313 follow-on).
   bool signSynced = false;
   uint64_t signTs = epochNowMs(signSynced);
+
+  bool needsAction[CLUSTER_MAX_MEMBERS] = {false};
   for (int i = 0; i < table.count; i++) {
-    const ClusterMemberDef& def = table.members[i];
-    if (clusterMemberIsSelf(def)) continue;
+    if (clusterMemberIsSelf(table.members[i])) continue;
     // While a rollout upload streams to a member, its flash writes hog the
     // follower's async_tcp task — regular contact would time out and read
     // as failures. Skip it; the upload round-trip IS the contact (#276).
@@ -429,11 +438,16 @@ static int collectMemberWork(MemberWorkItem* items) {
         followerPush.memberIndex == i) {
       continue;
     }
-    ClusterLeaderAction action = clusterMemberNextAction(runtimes[i], nowMs);
-    if (action == ClusterLeaderAction::None) continue;
+    needsAction[i] =
+        clusterMemberNextAction(runtimes[i], nowMs) != ClusterLeaderAction::None;
+  }
 
+  int pick = clusterFanoutNext(fanoutCursor, needsAction, table.count);
+  if (pick >= 0) {
+    const ClusterMemberDef& def = table.members[pick];
+    ClusterLeaderAction action = clusterMemberNextAction(runtimes[pick], nowMs);
     MemberWorkItem& item = items[count++];
-    item.index = i;
+    item.index = pick;
     item.action = action;
     String host(def.host);
     switch (action) {
@@ -444,15 +458,15 @@ static int collectMemberWork(MemberWorkItem* items) {
         item.url = "http://" + host + "/cluster/join";
         // Mint the per-member wire-auth key once (#313 follow-on); reused
         // across rejoins so the key stays stable while the membership does.
-        if (!runtimes[i].hmacKeyValid) {
-          clusterMintKey(runtimes[i].hmacKey);
-          runtimes[i].hmacKeyValid = true;
+        if (!runtimes[pick].hmacKeyValid) {
+          clusterMintKey(runtimes[pick].hmacKey);
+          runtimes[pick].hmacKeyValid = true;
         }
         item.body = "leaderName=" + urlEncode(leaderDeviceName) +
                     "&leaderHost=" + urlEncode(WiFi.localIP().toString()) +
                     "&row=" + String((int)def.row) +
                     "&epoch=" + String((unsigned long)epoch) +
-                    "&key=" + clusterKeyToHex(runtimes[i].hmacKey);
+                    "&key=" + clusterKeyToHex(runtimes[pick].hmacKey);
         break;
       }
       case ClusterLeaderAction::Render: {
@@ -465,17 +479,17 @@ static int collectMemberWork(MemberWorkItem* items) {
         uint32_t seq = ++seqCounter;
         item.body = "epoch=" + String((unsigned long)epoch) +
                     "&seq=" + String((unsigned long)seq) +
-                    "&text=" + urlEncode(segments[i]) +
+                    "&text=" + urlEncode(segments[pick]) +
                     "&speed=" + String(gridSpeed) +
                     "&commitAtMs=" + String((unsigned long long)gridCommitAtMs);
         // Sign the content (#313 follow-on) once a key is negotiated — the
         // canonical fields mirror what the follower reconstructs from the
         // wire params, so a captured mac can't be reused for other text.
-        if (runtimes[i].hmacKeyValid) {
-          String msg = clusterHmacRenderMsg(signTs, epoch, seq, segments[i],
+        if (runtimes[pick].hmacKeyValid) {
+          String msg = clusterHmacRenderMsg(signTs, epoch, seq, segments[pick],
                                             gridSpeed, gridCommitAtMs);
           item.body += "&ts=" + clusterU64ToStr(signTs) + "&mac=" +
-                       clusterHmacSign(runtimes[i].hmacKey, msg);
+                       clusterHmacSign(runtimes[pick].hmacKey, msg);
         }
         break;
       }

--- a/firmware/v2/Master/ClusterLeader.cpp
+++ b/firmware/v2/Master/ClusterLeader.cpp
@@ -1128,40 +1128,53 @@ static void followerPushServiceTick() {
   }
 }
 
-// #321: force-ping every member once with the hold-bearing digest so a planned
-// reboot's hold reaches them promptly (the normal fan-out is one-per-tick on a
-// ~10 s cadence — too slow before a reboot). Self-contained + off the hot path;
-// yields between blocking sends so it can't starve core-0 idle (cf. #320).
-static void rebootHoldFanout() {
-  struct Target { String host; String body; };
-  static Target targets[CLUSTER_MAX_MEMBERS];
-  int n = 0;
-  {
-    LeaderLock lock;
-    if (!clusterLeaderEnabled()) return;
-    ClusterLeaderStatus st;
-    statusFillLocked(st);
-    String mirror[CLUSTER_MAX_MEMBERS];
-    DisplaySnapshot snap = displaySnapshotGet();
-    int rowCount =
-        clusterMirrorRows(table, segments, String(snap.currentText),
-                          displayAlignmentFromString(gridAlignment), mirror);
-    String body = clusterBuildDigest(0, leaderDeviceName,
-                                     WiFi.localIP().toString(),
-                                     clusterTableToString(table), mirror,
-                                     rowCount, st, rebootHoldMs);
-    if (body != digestLastBody) {
-      digestLastBody = body;
-      digestGen++;
-    }
-    String digest = "{\"gen\":" + String((unsigned long)digestGen) +
-                    body.substring(strlen("{\"gen\":0"));
-    String encoded = urlEncode(digest);
-    bool synced = false;
-    uint64_t ts = epochNowMs(synced);
-    for (int i = 0; i < table.count && n < CLUSTER_MAX_MEMBERS; i++) {
+// #321 reboot-hold delivery. Built once when a reboot is announced, then sent
+// ONE member per clusterLeaderTick (see the tick) — the naive "ping everyone in
+// one call" is the exact core-0-starving burst #320 was written to eliminate
+// (up to 7 dead hosts × the 1.5 s HTTP timeout ≫ the 5 s task watchdog). Non-
+// degraded members are queued FIRST so the reachable rows — the ones that could
+// actually spuriously take over — get the hold within the drain's bounded wait
+// even if some members are dead and burn their timeouts at the tail.
+struct RebootHoldTarget {
+  String host;
+  String body;
+};
+static RebootHoldTarget rebootHoldTargets[CLUSTER_MAX_MEMBERS];
+static int rebootHoldCount = 0;
+static int rebootHoldCursor = 0;
+
+static void rebootHoldBuildTargets() {
+  LeaderLock lock;
+  rebootHoldCount = 0;
+  rebootHoldCursor = 0;
+  if (!clusterLeaderEnabled()) return;
+  ClusterLeaderStatus st;
+  statusFillLocked(st);
+  String mirror[CLUSTER_MAX_MEMBERS];
+  DisplaySnapshot snap = displaySnapshotGet();
+  int rowCount =
+      clusterMirrorRows(table, segments, String(snap.currentText),
+                        displayAlignmentFromString(gridAlignment), mirror);
+  String body =
+      clusterBuildDigest(0, leaderDeviceName, WiFi.localIP().toString(),
+                         clusterTableToString(table), mirror, rowCount, st,
+                         rebootHoldMs);
+  if (body != digestLastBody) {
+    digestLastBody = body;
+    digestGen++;
+  }
+  String digest = "{\"gen\":" + String((unsigned long)digestGen) +
+                  body.substring(strlen("{\"gen\":0"));
+  String encoded = urlEncode(digest);
+  bool synced = false;
+  uint64_t ts = epochNowMs(synced);
+  // Pass 0 = reachable (non-degraded) members, pass 1 = degraded ones.
+  for (int pass = 0; pass < 2; pass++) {
+    for (int i = 0;
+         i < table.count && rebootHoldCount < CLUSTER_MAX_MEMBERS; i++) {
       if (clusterMemberIsSelf(table.members[i])) continue;
-      Target& t = targets[n++];
+      if (runtimes[i].degraded != (pass == 1)) continue;
+      RebootHoldTarget& t = rebootHoldTargets[rebootHoldCount++];
       t.host = table.members[i].host;
       t.body = "digest=" + encoded + "&you=" + String(i);
       if (runtimes[i].hmacKeyValid) {
@@ -1171,13 +1184,6 @@ static void rebootHoldFanout() {
       }
     }
   }
-  for (int i = 0; i < n; i++) {
-    String resp;
-    clusterHttpRequest("http://" + targets[i].host + "/cluster/ping",
-                       targets[i].body, resp);
-    vTaskDelay(pdMS_TO_TICKS(1));  // feed core-0 idle between blocking sends
-  }
-  SerialPrintln("cluster: announced reboot-hold to " + String(n) + " member(s)");
 }
 
 // Called from the reboot drain (any task) before an intentional restart.
@@ -1203,11 +1209,27 @@ void clusterLeaderTick() {
   applyStagedConfig();
   if (!clusterLeaderEnabled()) return;
 
-  // #321: a pending reboot-hold pre-empts the normal fan-out — send it first
-  // and flag it done so the reboot drain can proceed.
+  // #321: deliver a pending reboot-hold ONE member per tick — watchdog-safe,
+  // same cadence as the normal fan-out (the 100 ms inter-tick vTaskDelay feeds
+  // core-0 idle between every blocking send). While it drains, this tick does
+  // ONLY the hold send so a tail of dead members can never stack two blocking
+  // ops in one tick. The reboot drain waits (bounded) on rebootHoldSent.
   if (rebootHoldPending.exchange(false)) {
-    rebootHoldFanout();
-    rebootHoldSent.store(true);
+    rebootHoldBuildTargets();
+    if (rebootHoldCount == 0) rebootHoldSent.store(true);  // nobody to tell
+  }
+  if (rebootHoldCursor < rebootHoldCount) {
+    String resp;
+    clusterHttpRequest(
+        "http://" + rebootHoldTargets[rebootHoldCursor].host + "/cluster/ping",
+        rebootHoldTargets[rebootHoldCursor].body, resp);
+    rebootHoldCursor++;
+    if (rebootHoldCursor >= rebootHoldCount) {
+      rebootHoldSent.store(true);
+      SerialPrintln("cluster: announced reboot-hold to " +
+                    String(rebootHoldCount) + " member(s)");
+    }
+    return;  // one blocking op this tick
   }
 
   serviceSelfRow();

--- a/firmware/v2/Master/ClusterLeader.cpp
+++ b/firmware/v2/Master/ClusterLeader.cpp
@@ -407,6 +407,16 @@ struct MemberWorkItem {
 // private: only collectMemberWork touches it, always under LeaderLock.
 static int fanoutCursor = -1;
 
+// #321 graceful-reboot hold. Before an intentional restart the leader stamps a
+// hold (ms) into its digest and force-pings every member once so a designated
+// backup doesn't take over during the reboot window. rebootHoldMs also rides
+// the normal ping digest while set. Cross-task: the reboot drain waits on
+// rebootHoldSent.
+static const uint32_t CLUSTER_REBOOT_HOLD_MS = 45000;  // < follower clamp (60s)
+static uint32_t rebootHoldMs = 0;
+static std::atomic<bool> rebootHoldPending{false};
+static std::atomic<bool> rebootHoldSent{false};
+
 // Builds the next round of outbound calls under the lock; the blocking
 // HTTP happens with the mutex RELEASED so submits/status reads never wait
 // on a slow follower. At most ONE member is contacted per tick (#320): a
@@ -517,7 +527,7 @@ static int collectMemberWork(MemberWorkItem* items) {
     String body = clusterBuildDigest(0, leaderDeviceName,
                                      WiFi.localIP().toString(),
                                      clusterTableToString(table), mirror,
-                                     rowCount, st);
+                                     rowCount, st, rebootHoldMs);
     if (body != digestLastBody) {
       digestLastBody = body;
       digestGen++;
@@ -1118,10 +1128,87 @@ static void followerPushServiceTick() {
   }
 }
 
+// #321: force-ping every member once with the hold-bearing digest so a planned
+// reboot's hold reaches them promptly (the normal fan-out is one-per-tick on a
+// ~10 s cadence — too slow before a reboot). Self-contained + off the hot path;
+// yields between blocking sends so it can't starve core-0 idle (cf. #320).
+static void rebootHoldFanout() {
+  struct Target { String host; String body; };
+  static Target targets[CLUSTER_MAX_MEMBERS];
+  int n = 0;
+  {
+    LeaderLock lock;
+    if (!clusterLeaderEnabled()) return;
+    ClusterLeaderStatus st;
+    statusFillLocked(st);
+    String mirror[CLUSTER_MAX_MEMBERS];
+    DisplaySnapshot snap = displaySnapshotGet();
+    int rowCount =
+        clusterMirrorRows(table, segments, String(snap.currentText),
+                          displayAlignmentFromString(gridAlignment), mirror);
+    String body = clusterBuildDigest(0, leaderDeviceName,
+                                     WiFi.localIP().toString(),
+                                     clusterTableToString(table), mirror,
+                                     rowCount, st, rebootHoldMs);
+    if (body != digestLastBody) {
+      digestLastBody = body;
+      digestGen++;
+    }
+    String digest = "{\"gen\":" + String((unsigned long)digestGen) +
+                    body.substring(strlen("{\"gen\":0"));
+    String encoded = urlEncode(digest);
+    bool synced = false;
+    uint64_t ts = epochNowMs(synced);
+    for (int i = 0; i < table.count && n < CLUSTER_MAX_MEMBERS; i++) {
+      if (clusterMemberIsSelf(table.members[i])) continue;
+      Target& t = targets[n++];
+      t.host = table.members[i].host;
+      t.body = "digest=" + encoded + "&you=" + String(i);
+      if (runtimes[i].hmacKeyValid) {
+        String msg = clusterHmacPingMsg(ts, digest, i);
+        t.body += "&ts=" + clusterU64ToStr(ts) + "&mac=" +
+                  clusterHmacSign(runtimes[i].hmacKey, msg);
+      }
+    }
+  }
+  for (int i = 0; i < n; i++) {
+    String resp;
+    clusterHttpRequest("http://" + targets[i].host + "/cluster/ping",
+                       targets[i].body, resp);
+    vTaskDelay(pdMS_TO_TICKS(1));  // feed core-0 idle between blocking sends
+  }
+  SerialPrintln("cluster: announced reboot-hold to " + String(n) + " member(s)");
+}
+
+// Called from the reboot drain (any task) before an intentional restart.
+void clusterLeaderAnnounceRebootHold() {
+  if (leaderMutex == nullptr || !clusterLeaderEnabled()) return;  // no followers
+  {
+    LeaderLock lock;
+    rebootHoldMs = CLUSTER_REBOOT_HOLD_MS;
+  }
+  rebootHoldSent.store(false);
+  rebootHoldPending.store(true);
+}
+
+// True once the hold has been fanned out — or immediately when not leading, so
+// a standalone board never waits.
+bool clusterLeaderRebootHoldSent() {
+  if (leaderMutex == nullptr || !clusterLeaderEnabled()) return true;
+  return rebootHoldSent.load();
+}
+
 void clusterLeaderTick() {
   if (leaderMutex == nullptr) return;
   applyStagedConfig();
   if (!clusterLeaderEnabled()) return;
+
+  // #321: a pending reboot-hold pre-empts the normal fan-out — send it first
+  // and flag it done so the reboot drain can proceed.
+  if (rebootHoldPending.exchange(false)) {
+    rebootHoldFanout();
+    rebootHoldSent.store(true);
+  }
 
   serviceSelfRow();
 

--- a/firmware/v2/Master/ClusterLeader.h
+++ b/firmware/v2/Master/ClusterLeader.h
@@ -94,6 +94,13 @@ bool clusterLeaderEnabled();
 // self-row staging/re-show, then the sequential HTTP fan-out.
 void clusterLeaderTick();
 
+// #321 graceful-reboot hold: before an intentional restart, announce a hold to
+// followers so a designated backup doesn't take over during the reboot window.
+// No-op when not leading. clusterTask fans it out; the reboot drain waits on
+// clusterLeaderRebootHoldSent() (true immediately when not leading).
+void clusterLeaderAnnounceRebootHold();
+bool clusterLeaderRebootHoldSent();
+
 // Producers hand LOGICAL grid content here when enabled. Identical
 // content dedups internally; changed content re-slices, stamps a shared
 // commitAt (~400 ms out) and marks the affected members dirty.

--- a/firmware/v2/Master/ClusterLeaderPolicy.h
+++ b/firmware/v2/Master/ClusterLeaderPolicy.h
@@ -91,6 +91,33 @@ inline ClusterLeaderAction clusterMemberNextAction(
   return ClusterLeaderAction::None;
 }
 
+// Round-robin fan-out selector (#320). The leader contacts at most ONE member
+// per tick: a promote-time catch-up makes every member due at once (all
+// un-joined after the runtime reset), and if one is a dead host it burns the
+// full HTTP timeout — doing the whole round in a single tick blocks core 0
+// past the 5 s task watchdog (the crash that motivated this). Scanning starts
+// just AFTER the last-served index and wraps, so a member stuck needing the
+// same op every tick (a dead host that never joins) can never starve the
+// healthy ones.
+//
+// `cursor` is the last-served member index (-1 = none served yet, and stale
+// values past `count` are normalized); it is advanced to the returned index.
+// `needsAction[i]` is true when member i has a due op this tick (the caller
+// derives it from clusterMemberNextAction). Returns the chosen index, or -1
+// when none are due (cursor left unchanged so progress resumes next tick).
+inline int clusterFanoutNext(int& cursor, const bool* needsAction, int count) {
+  if (count <= 0 || needsAction == nullptr) return -1;
+  int start = (cursor < 0 || cursor >= count) ? -1 : cursor;
+  for (int step = 1; step <= count; step++) {
+    int i = (start + step) % count;  // start == -1 → first probe is index 0
+    if (needsAction[i]) {
+      cursor = i;
+      return i;
+    }
+  }
+  return -1;
+}
+
 inline void clusterMemberOnSuccess(ClusterMemberRuntime& m, uint32_t nowMs) {
   m.failures = 0;
   m.degraded = false;

--- a/firmware/v2/Master/Tasks.cpp
+++ b/firmware/v2/Master/Tasks.cpp
@@ -52,8 +52,12 @@ static constexpr uint32_t NET_TASK_STACK = 8192;
 // espMqttClient internals + the 512 B discovery build buffers (#224); the
 // heartbeat's HWM column is the trim-down evidence.
 static constexpr uint32_t MQTT_TASK_STACK = 6144;
-// esp_http_client + String assembly for the cluster fan-out (#273).
-static constexpr uint32_t CLUSTER_TASK_STACK = 6144;
+// esp_http_client + String assembly for the cluster fan-out (#273). The digest
+// build puts a full ClusterLeaderStatus (8 members x 4 Strings) + String
+// mirror[8] on the stack; at the config-apply/leading peak 6144 left only ~620 B
+// HWM (bench, #321) — bumped to 8192 for margin (also covers the reboot-hold
+// fan-out, which builds the same objects). RAM is plentiful (150 KB+ free heap).
+static constexpr uint32_t CLUSTER_TASK_STACK = 8192;
 
 static constexpr UBaseType_t DISPLAY_TASK_PRIORITY = 3;  // flap timing wins
 static constexpr UBaseType_t DOMAIN_TASK_PRIORITY = 1;   // everything else

--- a/firmware/v2/Master/WebEndpoints.cpp
+++ b/firmware/v2/Master/WebEndpoints.cpp
@@ -2155,6 +2155,23 @@ void webEndpointsLoop(MasterSettings& settings, SettingsStore& store) {
     rebootDue = pendingReboot && millis() - rebootRequestedAtMs > 750;
   }
 
+  // #321: before an intentional reboot, announce a graceful hold to followers
+  // (once) and wait until clusterTask has fanned it out — so a designated
+  // backup doesn't take over during the reboot window. Bounded (4 s) so a stuck
+  // member can't block the reboot. clusterLeader* take the LEADER lock, so they
+  // run out here, never nested under the WebState lock above.
+  if (rebootDue) {
+    static bool rebootHoldAnnounced = false;
+    if (!rebootHoldAnnounced) {
+      rebootHoldAnnounced = true;
+      clusterLeaderAnnounceRebootHold();
+    }
+    if (!clusterLeaderRebootHoldSent() &&
+        millis() - rebootRequestedAtMs < 4000) {
+      rebootDue = false;  // hold not fanned out yet — hold the reboot
+    }
+  }
+
   // Outside the lock: configTzTime takes the LWIP core lock — keep the two
   // lock domains from ever nesting (v1 #48 parity: TZ applies rebootless).
   if (timezoneChanged) clockServiceApplyTz(settings);

--- a/firmware/v2/Master/WebEndpoints.cpp
+++ b/firmware/v2/Master/WebEndpoints.cpp
@@ -493,8 +493,10 @@ void webEndpointsInit(AsyncWebServer& server, MasterSettings& settings,
       request->send(404, "application/json", F("{\"present\":false}"));
       return;
     }
+    // Zero-init: if a partially-corrupted-but-parseable dump leaves a field
+    // untouched, we echo a deterministic 0, not stale heap bytes.
     auto* summary =
-        (esp_core_dump_summary_t*)malloc(sizeof(esp_core_dump_summary_t));
+        (esp_core_dump_summary_t*)calloc(1, sizeof(esp_core_dump_summary_t));
     if (summary == nullptr) {
       request->send(503, "application/json", F("{\"error\":\"oom\"}"));
       return;

--- a/firmware/v2/Master/WebEndpoints.cpp
+++ b/firmware/v2/Master/WebEndpoints.cpp
@@ -479,11 +479,15 @@ void webEndpointsInit(AsyncWebServer& server, MasterSettings& settings,
   });
 
   // --- coredump (#319) — remote crash diagnostics --------------------------
-  // CLOSED same-origin surface: deliberately NOT in clusterCorsPathAllowed, so
-  // a cross-origin browser cannot read the response (a coredump holds live RAM
-  // — HMAC per-member keys + WiFi credentials). GET-only and read-only; the
-  // coredump partition is written solely by the panic handler at crash time,
-  // so reading it from the async task is safe (same as /log/flash).
+  // The SUMMARY (task name + code addresses + backtrace PCs) carries NO
+  // secrets, so an unauthenticated GET is fine — same posture as /settings,
+  // /log/flash. It is always registered. The RAW image, in contrast, is a
+  // task-stack dump that CAN transiently hold HMAC key material / WiFi-cred
+  // fragments (a key mid-sign on clusterTask's stack); this device has no
+  // auth and CORS-closing does not stop a plain HTTP client, so raw is
+  // compiled out of shipped images and only appears in a build that opts in
+  // with -DCOREDUMP_RAW_ENABLE (deliberately OTA'd to a crashing board).
+  // Read-only; the coredump partition is written solely by the panic handler.
   server.on("/coredump/summary", HTTP_GET, [](AsyncWebServerRequest* request) {
     if (esp_core_dump_image_check() != ESP_OK) {
       request->send(404, "application/json", F("{\"present\":false}"));
@@ -536,9 +540,12 @@ void webEndpointsInit(AsyncWebServer& server, MasterSettings& settings,
     request->send(200, "application/json", out);
   });
 
-  // Raw ELF coredump for offline `espcoredump.py info_corefile` — the fallback
+#ifdef COREDUMP_RAW_ENABLE
+  // Raw ELF coredump for offline `esp-coredump info_corefile` — the fallback
   // when a summary backtrace reads corrupted. Streamed straight off the
-  // coredump partition (flash READ only, async-safe).
+  // coredump partition (flash READ only, async-safe). Opt-in only (see the
+  // summary comment above): task stacks can leak transient secrets, so this
+  // never ships in a release image.
   server.on("/coredump/raw", HTTP_GET, [](AsyncWebServerRequest* request) {
     if (esp_core_dump_image_check() != ESP_OK) {
       request->send(404, "text/plain", F("no coredump"));
@@ -575,6 +582,7 @@ void webEndpointsInit(AsyncWebServer& server, MasterSettings& settings,
                         "attachment; filename=\"coredump-" GIT_REV ".elf\"");
     request->send(response);
   });
+#endif  // COREDUMP_RAW_ENABLE
 
   // --- settings/message form (v1 wire contract) ----------------------------
   server.on("/", HTTP_POST, [](AsyncWebServerRequest* request) {

--- a/firmware/v2/Master/WebEndpoints.cpp
+++ b/firmware/v2/Master/WebEndpoints.cpp
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include <esp_partition.h>
+#include <esp_core_dump.h>  // #319: /coredump crash diagnostics
 
 #include "ApiIndex.h"
 #include "BuildVersion.h"
@@ -475,6 +476,104 @@ void webEndpointsInit(AsyncWebServer& server, MasterSettings& settings,
     }
     flashLogRequestClear();
     request->send(202, "text/plain", F("Flash log clear queued"));
+  });
+
+  // --- coredump (#319) — remote crash diagnostics --------------------------
+  // CLOSED same-origin surface: deliberately NOT in clusterCorsPathAllowed, so
+  // a cross-origin browser cannot read the response (a coredump holds live RAM
+  // — HMAC per-member keys + WiFi credentials). GET-only and read-only; the
+  // coredump partition is written solely by the panic handler at crash time,
+  // so reading it from the async task is safe (same as /log/flash).
+  server.on("/coredump/summary", HTTP_GET, [](AsyncWebServerRequest* request) {
+    if (esp_core_dump_image_check() != ESP_OK) {
+      request->send(404, "application/json", F("{\"present\":false}"));
+      return;
+    }
+    auto* summary =
+        (esp_core_dump_summary_t*)malloc(sizeof(esp_core_dump_summary_t));
+    if (summary == nullptr) {
+      request->send(503, "application/json", F("{\"error\":\"oom\"}"));
+      return;
+    }
+    if (esp_core_dump_get_summary(summary) != ESP_OK) {
+      free(summary);
+      request->send(500, "application/json",
+                    F("{\"present\":true,\"error\":\"summary-failed\"}"));
+      return;
+    }
+    char task[17];
+    memcpy(task, summary->exc_task, 16);
+    task[16] = '\0';
+    char hex[11];
+    String out;
+    out.reserve(640);
+    out += F("{\"present\":true,\"rev\":\"" GIT_REV "\",\"task\":");
+    appendJsonString(out, String(task));
+    snprintf(hex, sizeof(hex), "0x%08x", (unsigned)summary->exc_pc);
+    out += F(",\"pc\":\"");
+    out += hex;
+    out += F("\",\"excCause\":");
+    out += (unsigned)summary->ex_info.exc_cause;
+    snprintf(hex, sizeof(hex), "0x%08x", (unsigned)summary->ex_info.exc_vaddr);
+    out += F(",\"excVaddr\":\"");
+    out += hex;
+    out += F("\",\"coreDumpVersion\":");
+    out += (unsigned)summary->core_dump_version;
+    out += F(",\"backtraceCorrupted\":");
+    out += summary->exc_bt_info.corrupted ? F("true") : F("false");
+    out += F(",\"backtrace\":[");
+    uint32_t depth = summary->exc_bt_info.depth;
+    if (depth > 16) depth = 16;
+    for (uint32_t i = 0; i < depth; i++) {
+      if (i) out += ',';
+      snprintf(hex, sizeof(hex), "0x%08x", (unsigned)summary->exc_bt_info.bt[i]);
+      out += '"';
+      out += hex;
+      out += '"';
+    }
+    out += F("]}");
+    free(summary);
+    request->send(200, "application/json", out);
+  });
+
+  // Raw ELF coredump for offline `espcoredump.py info_corefile` — the fallback
+  // when a summary backtrace reads corrupted. Streamed straight off the
+  // coredump partition (flash READ only, async-safe).
+  server.on("/coredump/raw", HTTP_GET, [](AsyncWebServerRequest* request) {
+    if (esp_core_dump_image_check() != ESP_OK) {
+      request->send(404, "text/plain", F("no coredump"));
+      return;
+    }
+    size_t addr = 0, size = 0;
+    if (esp_core_dump_image_get(&addr, &size) != ESP_OK || size == 0) {
+      request->send(500, "text/plain", F("coredump image unavailable"));
+      return;
+    }
+    const esp_partition_t* part = esp_partition_find_first(
+        ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_COREDUMP, nullptr);
+    if (part == nullptr) {
+      request->send(500, "text/plain", F("no coredump partition"));
+      return;
+    }
+    // image_get() returns an ABSOLUTE flash address — translate to a
+    // partition-relative offset for esp_partition_read.
+    size_t offset = addr - part->address;
+    AsyncWebServerResponse* response = request->beginChunkedResponse(
+        "application/octet-stream",
+        [part, offset, size](uint8_t* buffer, size_t maxLen,
+                             size_t index) -> size_t {
+          if (index >= size) return 0;
+          size_t remaining = size - index;
+          size_t toRead = remaining < maxLen ? remaining : maxLen;
+          if (esp_partition_read(part, offset + index, buffer, toRead) !=
+              ESP_OK) {
+            return 0;  // abort the stream
+          }
+          return toRead;
+        });
+    response->addHeader("Content-Disposition",
+                        "attachment; filename=\"coredump-" GIT_REV ".elf\"");
+    request->send(response);
   });
 
   // --- settings/message form (v1 wire contract) ----------------------------

--- a/firmware/v2/Master/test/test_cluster_digest/test_main.cpp
+++ b/firmware/v2/Master/test/test_cluster_digest/test_main.cpp
@@ -411,8 +411,43 @@ static void test_csrf_gate_allows_lan_ui_and_server_to_server() {
   TEST_ASSERT_FALSE(clusterCsrfRejectPost(false, true, "http://evil.example.com"));
 }
 
+// #321 eligible-successor list -------------------------------------------------
+
+static void test_successor_list_includes_s3_followers() {
+  ClusterLeaderStatus st = makeStatus();  // member 0 = self, member 1 = S3 peer
+  // Self is excluded; the S3 follower (empty plat = same platform) is index 1.
+  TEST_ASSERT_EQUAL_STRING("1", clusterSuccessorList(st).c_str());
+}
+
+static void test_successor_list_excludes_esp01() {
+  ClusterLeaderStatus st = makeStatus();
+  st.members[1].plat = "esp01";  // foreign — never a takeover candidate
+  TEST_ASSERT_EQUAL_STRING("", clusterSuccessorList(st).c_str());
+}
+
+static void test_successor_list_orders_multiple_s3_by_index() {
+  ClusterLeaderStatus st = makeStatus();
+  st.memberCount = 4;
+  st.members[2].host = "192.168.1.50";
+  st.members[2].plat = "esp32s3";
+  st.members[3].host = "192.168.1.51";
+  st.members[3].plat = "esp01";  // excluded
+  TEST_ASSERT_EQUAL_STRING("1,2", clusterSuccessorList(st).c_str());
+}
+
+static void test_digest_carries_succ_field() {
+  ClusterLeaderStatus st = makeStatus();
+  String rows[1] = {"HELLO"};
+  String d = clusterBuildDigest(3, "wall", "192.168.1.2", "a|0|0|16", rows, 1, st);
+  TEST_ASSERT_TRUE(d.indexOf("\"succ\":\"1\"") >= 0);
+}
+
 int main(int, char**) {
   UNITY_BEGIN();
+  RUN_TEST(test_successor_list_includes_s3_followers);
+  RUN_TEST(test_successor_list_excludes_esp01);
+  RUN_TEST(test_successor_list_orders_multiple_s3_by_index);
+  RUN_TEST(test_digest_carries_succ_field);
   RUN_TEST(test_fault_mask_all_healthy_is_zeroes);
   RUN_TEST(test_fault_mask_bit_is_unit_index);
   RUN_TEST(test_fault_mask_width_rounds_nibbles_up);

--- a/firmware/v2/Master/test/test_cluster_digest/test_main.cpp
+++ b/firmware/v2/Master/test/test_cluster_digest/test_main.cpp
@@ -440,6 +440,15 @@ static void test_digest_carries_succ_field() {
   String rows[1] = {"HELLO"};
   String d = clusterBuildDigest(3, "wall", "192.168.1.2", "a|0|0|16", rows, 1, st);
   TEST_ASSERT_TRUE(d.indexOf("\"succ\":\"1\"") >= 0);
+  TEST_ASSERT_TRUE(d.indexOf("\"hold\":0") >= 0);  // #321: 0 unless rebooting
+}
+
+static void test_digest_carries_hold_when_rebooting() {
+  ClusterLeaderStatus st = makeStatus();
+  String rows[1] = {"HELLO"};
+  String d = clusterBuildDigest(3, "wall", "192.168.1.2", "a|0|0|16", rows, 1, st,
+                                45000);
+  TEST_ASSERT_TRUE(d.indexOf("\"hold\":45000") >= 0);
 }
 
 int main(int, char**) {
@@ -448,6 +457,7 @@ int main(int, char**) {
   RUN_TEST(test_successor_list_excludes_esp01);
   RUN_TEST(test_successor_list_orders_multiple_s3_by_index);
   RUN_TEST(test_digest_carries_succ_field);
+  RUN_TEST(test_digest_carries_hold_when_rebooting);
   RUN_TEST(test_fault_mask_all_healthy_is_zeroes);
   RUN_TEST(test_fault_mask_bit_is_unit_index);
   RUN_TEST(test_fault_mask_width_rounds_nibbles_up);

--- a/firmware/v2/Master/test/test_cluster_follower_policy/test_main.cpp
+++ b/firmware/v2/Master/test/test_cluster_follower_policy/test_main.cpp
@@ -298,6 +298,75 @@ static void test_promote_allowed_only_in_local_fallback() {
   TEST_ASSERT_FALSE(clusterFollowerCanPromote(st));
 }
 
+// --- ranked auto-takeover (#321) -----------------------------------------------
+
+static void test_successor_rank_parses_position() {
+  TEST_ASSERT_EQUAL(0, clusterSuccessorRank("2,3", 2));
+  TEST_ASSERT_EQUAL(1, clusterSuccessorRank("2,3", 3));
+  TEST_ASSERT_EQUAL(0, clusterSuccessorRank("4", 4));
+  TEST_ASSERT_EQUAL(2, clusterSuccessorRank("5,1,3", 3));
+  TEST_ASSERT_EQUAL(-1, clusterSuccessorRank("2,3", 5));   // not a successor
+  TEST_ASSERT_EQUAL(-1, clusterSuccessorRank("", 2));      // no list
+  TEST_ASSERT_EQUAL(-1, clusterSuccessorRank("2,3", -1));  // no self index
+}
+
+// Build a Grace-phase follower whose leader last spoke at t=1000.
+static ClusterFollowerState makeGraceSince1000() {
+  ClusterFollowerState st = makeClustered(1000, 7);
+  clusterFollowerTick(st, 1000 + CLUSTER_CONTACT_FRESH_MS);  // -> Grace
+  return st;
+}
+
+static void test_auto_promote_ignores_non_successor() {
+  ClusterFollowerState st = makeGraceSince1000();
+  // Way past any threshold, but rank -1 (an ESP-01 / foreign board) never fires.
+  TEST_ASSERT_FALSE(clusterFollowerAutoPromoteDue(st, -1, 0, 1000000));
+}
+
+static void test_auto_promote_fires_at_threshold_for_primary() {
+  ClusterFollowerState st = makeGraceSince1000();  // lastContactMs == 1000
+  // rank 0 → threshold = 30 s of silence.
+  TEST_ASSERT_FALSE(clusterFollowerAutoPromoteDue(
+      st, 0, 0, 1000 + CLUSTER_AUTO_TAKEOVER_MS - 1));
+  TEST_ASSERT_TRUE(clusterFollowerAutoPromoteDue(
+      st, 0, 0, 1000 + CLUSTER_AUTO_TAKEOVER_MS));
+}
+
+static void test_auto_promote_staggered_by_rank() {
+  ClusterFollowerState st = makeGraceSince1000();
+  uint32_t primaryFire = 1000 + CLUSTER_AUTO_TAKEOVER_MS;
+  // At the primary's fire time the secondary (rank 1) must NOT yet fire.
+  TEST_ASSERT_FALSE(clusterFollowerAutoPromoteDue(st, 1, 0, primaryFire));
+  // It fires one stagger later.
+  TEST_ASSERT_TRUE(clusterFollowerAutoPromoteDue(
+      st, 1, 0, primaryFire + CLUSTER_AUTO_TAKEOVER_STAGGER_MS));
+}
+
+static void test_auto_promote_suppressed_by_hold() {
+  ClusterFollowerState st = makeGraceSince1000();
+  uint32_t now = 1000 + CLUSTER_AUTO_TAKEOVER_MS + 10000;  // well past threshold
+  uint32_t holdUntil = now + 5000;                          // hold still active
+  TEST_ASSERT_FALSE(clusterFollowerAutoPromoteDue(st, 0, holdUntil, now));
+  // Once the hold expires it fires.
+  TEST_ASSERT_TRUE(clusterFollowerAutoPromoteDue(st, 0, holdUntil, holdUntil));
+}
+
+static void test_auto_promote_not_while_leader_fresh() {
+  // Still Clustered (leader in contact) — never auto-promote, even if the
+  // clock is arbitrarily far ahead.
+  ClusterFollowerState st = makeClustered(1000, 7);
+  TEST_ASSERT_FALSE(clusterFollowerAutoPromoteDue(st, 0, 0, 1000000));
+  // Standalone (no membership) likewise.
+  ClusterFollowerState fresh;
+  TEST_ASSERT_FALSE(clusterFollowerAutoPromoteDue(fresh, 0, 0, 1000000));
+}
+
+static void test_hold_deadline_clamps() {
+  TEST_ASSERT_EQUAL_UINT32(6000, clusterAutoTakeoverHoldDeadline(5000, 1000));
+  TEST_ASSERT_EQUAL_UINT32(1000 + CLUSTER_AUTO_TAKEOVER_HOLD_MAX_MS,
+                           clusterAutoTakeoverHoldDeadline(999999, 1000));
+}
+
 int main(int, char**) {
   UNITY_BEGIN();
   RUN_TEST(test_boot_without_membership_is_standalone);
@@ -333,5 +402,12 @@ int main(int, char**) {
   RUN_TEST(test_join_conflict_allows_takeover_once_contact_is_stale);
   RUN_TEST(test_join_conflict_never_fires_outside_clustered);
   RUN_TEST(test_promote_allowed_only_in_local_fallback);
+  RUN_TEST(test_successor_rank_parses_position);
+  RUN_TEST(test_auto_promote_ignores_non_successor);
+  RUN_TEST(test_auto_promote_fires_at_threshold_for_primary);
+  RUN_TEST(test_auto_promote_staggered_by_rank);
+  RUN_TEST(test_auto_promote_suppressed_by_hold);
+  RUN_TEST(test_auto_promote_not_while_leader_fresh);
+  RUN_TEST(test_hold_deadline_clamps);
   return UNITY_END();
 }

--- a/firmware/v2/Master/test/test_cluster_leader_policy/test_main.cpp
+++ b/firmware/v2/Master/test/test_cluster_leader_policy/test_main.cpp
@@ -251,6 +251,53 @@ static void test_json_field_extraction() {
   TEST_ASSERT_EQUAL(-1, clusterExtractJsonInt(body, "idth", -1));
 }
 
+// --- one-op-per-tick fan-out round-robin (#320) --------------------------------
+
+static void test_fanout_none_due_returns_negative() {
+  int cursor = -1;
+  bool none[3] = {false, false, false};
+  TEST_ASSERT_EQUAL(-1, clusterFanoutNext(cursor, none, 3));
+  TEST_ASSERT_EQUAL(-1, clusterFanoutNext(cursor, nullptr, 0));
+}
+
+static void test_fanout_serves_one_then_round_robins() {
+  int cursor = -1;
+  bool all[3] = {true, true, true};
+  // One member per call, in order, wrapping — never all at once.
+  TEST_ASSERT_EQUAL(0, clusterFanoutNext(cursor, all, 3));
+  TEST_ASSERT_EQUAL(1, clusterFanoutNext(cursor, all, 3));
+  TEST_ASSERT_EQUAL(2, clusterFanoutNext(cursor, all, 3));
+  TEST_ASSERT_EQUAL(0, clusterFanoutNext(cursor, all, 3));  // wrap
+}
+
+static void test_fanout_skips_members_with_no_due_op() {
+  int cursor = -1;
+  bool some[3] = {true, false, true};
+  TEST_ASSERT_EQUAL(0, clusterFanoutNext(cursor, some, 3));
+  TEST_ASSERT_EQUAL(2, clusterFanoutNext(cursor, some, 3));  // 1 skipped
+  TEST_ASSERT_EQUAL(0, clusterFanoutNext(cursor, some, 3));  // wrap past 1
+}
+
+// The regression that caused #320: a stuck member (a dead host that stays
+// un-joined every tick) must not monopolize the fan-out — the healthy member
+// still gets served every other tick.
+static void test_fanout_stuck_member_does_not_starve_others() {
+  int cursor = -1;
+  bool stuck[2] = {true, true};  // index 0 = dead host, always due
+  TEST_ASSERT_EQUAL(0, clusterFanoutNext(cursor, stuck, 2));
+  TEST_ASSERT_EQUAL(1, clusterFanoutNext(cursor, stuck, 2));  // healthy served
+  TEST_ASSERT_EQUAL(0, clusterFanoutNext(cursor, stuck, 2));
+  TEST_ASSERT_EQUAL(1, clusterFanoutNext(cursor, stuck, 2));  // and again
+}
+
+// A membership shrink can leave the cursor past the new end; it must normalize
+// rather than index out of bounds or skip everyone.
+static void test_fanout_normalizes_stale_cursor() {
+  int cursor = 5;  // stale: count is now 3
+  bool some[3] = {false, true, false};
+  TEST_ASSERT_EQUAL(1, clusterFanoutNext(cursor, some, 3));
+}
+
 int main(int, char**) {
   UNITY_BEGIN();
   RUN_TEST(test_fresh_member_needs_join);
@@ -272,5 +319,10 @@ int main(int, char**) {
   RUN_TEST(test_self_member_is_empty_host);
   RUN_TEST(test_json_field_extraction);
   RUN_TEST(test_join_reply_plat_parses_and_defaults_empty);
+  RUN_TEST(test_fanout_none_due_returns_negative);
+  RUN_TEST(test_fanout_serves_one_then_round_robins);
+  RUN_TEST(test_fanout_skips_members_with_no_due_op);
+  RUN_TEST(test_fanout_stuck_member_does_not_starve_others);
+  RUN_TEST(test_fanout_normalizes_stale_cursor);
   return UNITY_END();
 }


### PR DESCRIPTION
Closes #319, #320, #321. Spec: `docs/superpowers/specs/2026-07-17-cluster-ranked-auto-takeover-design.md`.

## What
Three pieces, one arc — a bench leader died and nothing took over:
- **#319 `/coredump` endpoint** — `GET /coredump/summary` (task + backtrace, always on, no secrets) + `/coredump/raw` behind `-DCOREDUMP_RAW_ENABLE` (task-stack dump can hold key fragments — closed/opt-in). Closed same-origin surface. Used to root-cause #320.
- **#320 TWDT crash fix** — the leader fan-out contacted EVERY due member in one clusterTask tick; at promote (all un-joined, one a dead host burning the 1.5s HTTP timeout) it starved core-0 idle past the 5s task watchdog (coredump: victim IDLE0). Fix: pure round-robin `clusterFanoutNext` → one blocking op per tick.
- **#321 ranked auto-takeover** — leader ships an ordered eligible-successor list (`succ`, S3-only, ESP-01/foreign excluded) + a graceful-reboot `hold` in the already-HMAC-signed ping digest; an S3 successor self-promotes on a 30s + rank-staggered silence; a planned leader reboot/OTA force-pings a hold so no takeover fires during the reboot window. Refactored promote into a shared manual/auto core (TOCTOU-safe). Cooldown after a promote breaks false-positive churn. ESP-01 unchanged (never a candidate).

## Verification
- **717 Master native tests green**, ESP-01 tree builds, target builds.
- **cpp-reviewer gate**: 1 HIGH (reboot-hold burst reintroduced the #320 shape) + 1 MEDIUM + 2 LOW — all fixed.
- **Bench (physical cluster: S3 leader .20 + S3 successor .91 w/ 16 units + ESP-01 .121):**
  - Pull-plug drill: leader killed → `.91` **AUTO-PROMOTED**, drove the wall + ESP-01. **Reset reason Brownout, NOT Task watchdog** — #320 fix held; cluster stack HWM 4.1KB free (post stack-bump 8192).
  - Failback: old leader returned → **sticky-demoted, rejoined as a follower**. Zero split-brain.
  - Graceful hold: successor did **not** promote during the leader's OTA reboot.
  - Root-caused + fixed on-bench: clock-mode render churn destabilizes contact (spurious-promote churn → cooldown fix); cluster task stack 620B→8192 bump.

## Follow-ups (filed separately, not blocking)
`.91` 16-unit inrush brownout (#305-family), flash-log missing timestamps, clock-mode contact fragility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)