### PR TITLE
reliability(v2): TWDT app-task coverage (#314)

### DIFF
--- a/docs/superpowers/plans/2026-07-18-master-twdt-coverage.md
+++ b/docs/superpowers/plans/2026-07-18-master-twdt-coverage.md
@@ -1,0 +1,460 @@
+# Master TWDT App-Task Coverage (#314) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a genuinely hung application task on the ESP32-S3 master auto-recover via a watchdog reboot, without false-tripping during legitimate long operations (unit reflash, OTA, cluster fan-out).
+
+**Architecture:** Bump the ESP-IDF Task Watchdog (TWDT) timeout 5 s → 30 s via the tracked `custom_sdkconfig`; subscribe all 5 application FreeRTOS tasks with `esp_task_wdt_add(NULL)` and feed with `esp_task_wdt_reset()` at each loop top; feed *inside* long ops at progress points so a genuine wedge (e.g. an I2C driver hang) is still caught within ~30 s. The OTA write runs in the AsyncTCP task (not subscribed) and is left to the #313 stall-abort + CPU0 idle check.
+
+**Tech Stack:** ESP-IDF `esp_task_wdt` API, Arduino-ESP32 (pioarduino hybrid), FreeRTOS, PlatformIO; pytest for the config-regression guard.
+
+**Spec:** `docs/superpowers/specs/2026-07-18-master-twdt-coverage-design.md`
+
+## Global Constraints
+
+- Target `firmware/v2/Master` only. ESP-01 follower and Rescue are out of scope.
+- Ships post-v2.0.0 → this is a **v2.0.1** reliability patch (or folded into a v2.1 "harden the wall" batch). Do NOT bump the version in any code/commit here.
+- The 30 s timeout goes in `platformio.ini`'s `custom_sdkconfig` (tracked), NEVER the gitignored generated `sdkconfig.defaults`.
+- Keep `CONFIG_ESP_TASK_WDT_PANIC=y` (timeout → reboot) and the existing CPU0 idle check. Do NOT enable the CPU1 idle check.
+- Feed-inside, never unsubscribe: do not use `esp_task_wdt_delete()` around long ops (it would blind the dog to the I2C-wedge hang class #314 targets).
+- Boot/reliability change → risk-tiered review always applies (cpp-reviewer over the combined branch diff). Bench is the E2E gate.
+- Branch: `feat/master-twdt-314` (already created, carries the spec commits).
+- Run all `pio`/`pytest` commands from `firmware/v2/Master/`.
+
+## File Structure
+
+- **Create** `firmware/v2/Master/TaskWatchdog.h` — two inline target-only helpers (`wdtSubscribeSelf()`, `wdtFeed()`). Dependency-free except `<esp_task_wdt.h>`/`<esp_err.h>`. One responsibility: wrap the TWDT subscribe/feed calls.
+- **Create** `firmware/v2/Master/tests/test_task_watchdog_config.py` — pytest asserting `custom_sdkconfig` carries the 30 s timeout and PANIC stays on.
+- **Modify** `firmware/v2/Master/platformio.ini` — add `CONFIG_ESP_TASK_WDT_TIMEOUT_S=30` to `custom_sdkconfig`; add an optional `-D TWDT_HANG_TEST` build flag comment for bench.
+- **Modify** `firmware/v2/Master/Tasks.cpp` — subscribe + feed the 5 task loops; feed inside `runReflashJob` batches, the self-test poll, and boot-home stagger; optional hang-test hook.
+- **Modify** `firmware/v2/Master/ClusterLeader.cpp` — feed inside `clusterLeaderTick`'s member fan-out and after the three service ticks.
+
+---
+
+### Task 1: Config timeout bump + regression guard (real TDD)
+
+**Files:**
+- Create: `firmware/v2/Master/tests/test_task_watchdog_config.py`
+- Modify: `firmware/v2/Master/platformio.ini` (the `custom_sdkconfig =` block, currently line ~52)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the guarantee that the built firmware runs the TWDT at 30 s with panic-reboot on.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `firmware/v2/Master/tests/test_task_watchdog_config.py`:
+
+```python
+"""TWDT config guard (#314).
+
+The effective ESP_TASK_WDT_TIMEOUT_S lives in the generated (gitignored)
+sdkconfig; the tracked source is platformio.ini's custom_sdkconfig. This
+test pins that source so a future edit can't silently drop the 30 s override
+or the panic-reboot behaviour the unattended wall depends on.
+
+Run with:
+    pytest tests/
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+PROJECT_DIR = pathlib.Path(__file__).resolve().parent.parent
+INI_PATH = PROJECT_DIR / "platformio.ini"
+
+
+def custom_sdkconfig_lines() -> list[str]:
+    """Return the entries of the [env:master] custom_sdkconfig block."""
+    text = INI_PATH.read_text()
+    m = re.search(r"^custom_sdkconfig\s*=\s*$(.*?)^\S", text,
+                  re.MULTILINE | re.DOTALL)
+    assert m, "custom_sdkconfig block not found in platformio.ini"
+    lines = []
+    for raw in m.group(1).splitlines():
+        stripped = raw.strip()
+        if stripped and not stripped.startswith(";"):
+            lines.append(stripped)
+    return lines
+
+
+def test_task_wdt_timeout_is_30s():
+    assert "CONFIG_ESP_TASK_WDT_TIMEOUT_S=30" in custom_sdkconfig_lines()
+
+
+def test_task_wdt_panic_not_disabled():
+    # PANIC defaults on (framework) and must not be turned off here — a
+    # timeout must reboot, not just warn.
+    assert "CONFIG_ESP_TASK_WDT_PANIC=n" not in custom_sdkconfig_lines()
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd firmware/v2/Master && python -m pytest tests/test_task_watchdog_config.py -v`
+Expected: `test_task_wdt_timeout_is_30s` FAILS (the line is not yet in `custom_sdkconfig`); `test_task_wdt_panic_not_disabled` passes.
+
+- [ ] **Step 3: Add the timeout to `custom_sdkconfig`**
+
+In `firmware/v2/Master/platformio.ini`, change the block from:
+
+```
+custom_sdkconfig =
+  CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y
+```
+
+to:
+
+```
+custom_sdkconfig =
+  CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y
+  ; TWDT (#314): 30 s app-task watchdog. 5 s (framework default) is too tight
+  ; for legitimate long ops; PANIC + CPU0 idle check stay as framework defaults.
+  CONFIG_ESP_TASK_WDT_TIMEOUT_S=30
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd firmware/v2/Master && python -m pytest tests/test_task_watchdog_config.py -v`
+Expected: both tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add firmware/v2/Master/tests/test_task_watchdog_config.py firmware/v2/Master/platformio.ini
+git commit -m "feat(#314): 30 s TWDT timeout in custom_sdkconfig + regression guard"
+```
+
+---
+
+### Task 2: `TaskWatchdog.h` helpers
+
+**Files:**
+- Create: `firmware/v2/Master/TaskWatchdog.h`
+
+**Interfaces:**
+- Consumes: `<esp_task_wdt.h>` (`esp_task_wdt_add`, `esp_task_wdt_reset`), `<esp_err.h>` (`esp_err_t`, `esp_err_to_name`).
+- Produces:
+  - `esp_err_t wdtSubscribeSelf();` — subscribe the calling task; returns the raw `esp_err_t` so the caller logs on failure.
+  - `void wdtFeed();` — reset (feed) the TWDT for the calling task.
+
+- [ ] **Step 1: Create the header**
+
+Create `firmware/v2/Master/TaskWatchdog.h`:
+
+```cpp
+#pragma once
+// ESP-IDF Task Watchdog helpers (#314). Target-only glue — no pure logic, so
+// no native test; verified on the bench (a hung subscribed task must reboot
+// within ~30 s, and OTA/reflash must NOT false-reboot). Feed-inside, never
+// unsubscribe: keeping the dog live during long ops is the whole point (a
+// wedged I2C transaction must still trip it).
+#include <esp_err.h>
+#include <esp_task_wdt.h>
+
+// Subscribe the CALLING task to the TWDT. Returns ESP_OK on success; the
+// caller logs esp_err_to_name(err) otherwise. Never aborts.
+inline esp_err_t wdtSubscribeSelf() { return esp_task_wdt_add(nullptr); }
+
+// Feed the TWDT for the calling task. Call at each task loop top AND at
+// progress points inside long ops so no inter-feed span approaches 30 s.
+inline void wdtFeed() { esp_task_wdt_reset(); }
+```
+
+- [ ] **Step 2: Verify it compiles (build the project)**
+
+Run: `cd firmware/v2/Master && pio run`
+Expected: build SUCCEEDS (header is unused so far but must parse/link).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add firmware/v2/Master/TaskWatchdog.h
+git commit -m "feat(#314): TaskWatchdog.h — TWDT subscribe/feed helpers"
+```
+
+---
+
+### Task 3: Subscribe + feed the 5 task loops
+
+**Files:**
+- Modify: `firmware/v2/Master/Tasks.cpp` — `displayTaskMain` (subscribe before `for(;;)` at line ~460, feed at loop top), `clockTaskMain` (~797), `netTaskMain` (~908), `mqttTaskMain` (~926), `clusterTaskMain` (~941).
+
+**Interfaces:**
+- Consumes: `wdtSubscribeSelf()`, `wdtFeed()` (Task 2); `SerialPrintf` (already used throughout `Tasks.cpp`).
+- Produces: all 5 tasks watched; each feeds once per loop iteration.
+
+- [ ] **Step 1: Include the header**
+
+At the top of `firmware/v2/Master/Tasks.cpp`, add with the other project includes:
+
+```cpp
+#include "TaskWatchdog.h"
+```
+
+- [ ] **Step 2: Subscribe + feed each task**
+
+For EACH of the 5 task main functions, insert the subscribe call immediately before its `for (;;) {` loop, and the feed as the first statement inside the loop. Use the task's own name in the log string.
+
+`displayTaskMain` — the `for (;;)` is at line ~460, after the boot probe/auto-install block:
+
+```cpp
+  if (esp_err_t e = wdtSubscribeSelf(); e != ESP_OK)
+    SerialPrintf("wdt: display subscribe -> %s\n", esp_err_to_name(e));
+  for (;;) {
+    wdtFeed();
+    // ... existing loop body ...
+```
+
+`clockTaskMain` (~797):
+
+```cpp
+  if (esp_err_t e = wdtSubscribeSelf(); e != ESP_OK)
+    SerialPrintf("wdt: clock subscribe -> %s\n", esp_err_to_name(e));
+  for (;;) {
+    wdtFeed();
+```
+
+`netTaskMain` (~908):
+
+```cpp
+  if (esp_err_t e = wdtSubscribeSelf(); e != ESP_OK)
+    SerialPrintf("wdt: net subscribe -> %s\n", esp_err_to_name(e));
+  for (;;) {
+    wdtFeed();
+```
+
+`mqttTaskMain` (~926):
+
+```cpp
+  if (esp_err_t e = wdtSubscribeSelf(); e != ESP_OK)
+    SerialPrintf("wdt: mqtt subscribe -> %s\n", esp_err_to_name(e));
+  for (;;) {
+    wdtFeed();
+```
+
+`clusterTaskMain` (~941):
+
+```cpp
+  if (esp_err_t e = wdtSubscribeSelf(); e != ESP_OK)
+    SerialPrintf("wdt: cluster subscribe -> %s\n", esp_err_to_name(e));
+  for (;;) {
+    wdtFeed();
+    clusterLeaderTick();
+    vTaskDelay(pdMS_TO_TICKS(100));
+  }
+```
+
+- [ ] **Step 3: Build + confirm native tests still green**
+
+Run: `cd firmware/v2/Master && pio run && pio test -e native`
+Expected: build SUCCEEDS; native suite PASSES (no regression — this is target-only glue, ArduinoFake/native doesn't exercise it).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add firmware/v2/Master/Tasks.cpp
+git commit -m "feat(#314): subscribe + feed all 5 app tasks to the TWDT"
+```
+
+---
+
+### Task 4: Feed inside displayTask long ops
+
+**Files:**
+- Modify: `firmware/v2/Master/Tasks.cpp` — `runReflashJob` (def line ~278), the boot-home stagger loop (`for (int j = i; ...)` at line ~207), the self-test poll path (~616).
+
+**Interfaces:**
+- Consumes: `wdtFeed()` (Task 2).
+- Produces: no inter-feed span in displayTask exceeds ~30 s during reflash / self-test / boot-home; a genuine wedge still trips the dog.
+
+- [ ] **Step 1: Feed per boot-home batch**
+
+In the boot-home stagger loop in `Tasks.cpp` (the `for (int i = 0; i < n; ...)` batch loop around line 205, which commands a batch then waits for each unit to settle), add a feed at the top of each batch iteration:
+
+```cpp
+  for (int i = 0; i < n; /* advanced below */) {
+    wdtFeed();  // #314: each batch waits on unit settle — keep the dog fed
+    int batchN = 0;
+    for (int j = i; j < n && batchN < BOOT_HOME_BATCH_SIZE; j++) {
+      // ... existing ...
+```
+
+- [ ] **Step 2: Feed per reflash step in `runReflashJob`**
+
+`runReflashJob` (line ~278) streams unit hex in batches over I2C for tens of seconds. Add a `wdtFeed();` at the top of its main per-batch / per-unit loop body (the loop that iterates the units being flashed), and one after its concluding boot-home call (~line 449–453):
+
+```cpp
+    // top of the per-unit / per-batch reflash loop body:
+    wdtFeed();  // #314: I2C page-streaming is the longest displayTask op
+
+    // ... existing per-unit flash work ...
+```
+
+```cpp
+    // the reflash-ending boot-home (~449):
+    wdtFeed();  // #314: boot-home of just-flashed units
+    runReflashJob-local boot-home ...  // (keep existing call)
+```
+
+- [ ] **Step 3: Feed around the self-test poll**
+
+The self-test path (~line 616, where displayTask polls a unit's self-test outcome) can loop waiting on the unit. Add a `wdtFeed();` inside that poll loop:
+
+```cpp
+    // inside the self-test poll/wait loop:
+    wdtFeed();  // #314: self-test polls the unit until it reports an outcome
+```
+
+- [ ] **Step 4: Build + confirm native tests still green**
+
+Run: `cd firmware/v2/Master && pio run && pio test -e native`
+Expected: build SUCCEEDS; native suite PASSES.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add firmware/v2/Master/Tasks.cpp
+git commit -m "feat(#314): feed the TWDT inside displayTask long ops (reflash, self-test, boot-home)"
+```
+
+---
+
+### Task 5: Feed inside the cluster leader tick
+
+**Files:**
+- Modify: `firmware/v2/Master/ClusterLeader.cpp` — `clusterLeaderTick()` (def line ~1346): the member fan-out loop (~1385) and after `rolloutServiceTick()` / `followerPushServiceTick()` / `followerLogPullTick()` (~1408–1414).
+
+**Interfaces:**
+- Consumes: `wdtFeed()` (Task 2).
+- Produces: a single tick's multi-member fan-out plus the three service ticks never span > 30 s unfed; the reboot-hold path already returns one-member-per-tick and is covered by the loop-top feed (Task 3).
+
+- [ ] **Step 1: Include the header**
+
+At the top of `firmware/v2/Master/ClusterLeader.cpp`, add with the other project includes:
+
+```cpp
+#include "TaskWatchdog.h"
+```
+
+- [ ] **Step 2: Feed after each member and each service tick**
+
+In `clusterLeaderTick()`, the normal fan-out loop (line ~1385) does one blocking `clusterHttpRequest` (1.5 s timeout) per member. Feed after each, and after each of the three trailing service ticks:
+
+```cpp
+  for (int i = 0; i < count; i++) {
+    String body;
+    int status = clusterHttpRequest(items[i].url, items[i].body, body);
+    applyMemberResult(items[i], status, body);
+    wdtFeed();  // #314: up to CLUSTER_MAX_MEMBERS blocking sends in one tick
+  }
+
+  rolloutServiceTick();
+  wdtFeed();            // #314: a #276 firmware chunk write can block
+  followerPushServiceTick();
+  wdtFeed();            // #314: #304 relay chunk write
+  followerLogPullTick();
+  wdtFeed();            // #314: #318E log poll
+```
+
+(The reboot-hold `clusterHttpRequest` earlier in the tick already `return`s after one op, so the loop-top feed in Task 3 covers it — no extra feed needed there.)
+
+- [ ] **Step 3: Build + confirm native tests still green**
+
+Run: `cd firmware/v2/Master && pio run && pio test -e native`
+Expected: build SUCCEEDS; native suite (incl. `test_cluster_leader_policy`) PASSES.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add firmware/v2/Master/ClusterLeader.cpp
+git commit -m "feat(#314): feed the TWDT across the cluster leader tick fan-out"
+```
+
+---
+
+### Task 6: Bench hang-test hook + verification
+
+**Files:**
+- Modify: `firmware/v2/Master/platformio.ini` (`[env:master]` `build_flags`, ~line 100) — document an optional `-D TWDT_HANG_TEST` flag.
+- Modify: `firmware/v2/Master/Tasks.cpp` — a compile-guarded hang injection at the top of `displayTaskMain`'s loop.
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: a build-flag-gated way to prove the reboot on the bench, compiled out of shipping builds.
+
+- [ ] **Step 1: Add the compile-guarded hang hook**
+
+In `displayTaskMain`, immediately after the `wdtFeed();` at the loop top (Task 3), add:
+
+```cpp
+#ifdef TWDT_HANG_TEST
+    // #314 bench: after 20 s of normal running, wedge displayTask forever so
+    // the TWDT must reboot within ~30 s. NEVER defined in a shipping build.
+    if (millis() > 20000) { for (;;) { /* no wdtFeed() → dog fires */ } }
+#endif
+```
+
+- [ ] **Step 2: Document the flag in platformio.ini**
+
+Under `[env:master]` `build_flags` (~line 100), add a commented line (kept OFF):
+
+```
+  ; #314 bench only — wedge displayTask ~20 s after boot to prove the TWDT
+  ; reboot. Never enable in a shipping/OTA build. Uncomment to bench:
+  ; -D TWDT_HANG_TEST
+```
+
+- [ ] **Step 3: Build the normal (flag-off) image and confirm it's clean**
+
+Run: `cd firmware/v2/Master && pio run && pio test -e native`
+Expected: build SUCCEEDS (hang code compiled out); native PASSES.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add firmware/v2/Master/platformio.ini firmware/v2/Master/Tasks.cpp
+git commit -m "test(#314): compile-guarded TWDT hang hook for bench verification"
+```
+
+- [ ] **Step 5: cpp-reviewer gate (risk-tiered — always for boot/reliability)**
+
+Run the cpp-reviewer agent over the combined branch diff (`git diff master...feat/master-twdt-314`). Address CRITICAL/HIGH; fix MEDIUM where reasonable.
+
+- [ ] **Step 6: Bench verification (E2E gate — via VPN board access)**
+
+Stage the normal image, OTA it to the bench S3, and run:
+1. Build once WITH `-D TWDT_HANG_TEST`, flash → confirm the board reboots ~30 s after boot with a TWDT/panic reset reason in the boot banner. Re-flash the clean (flag-off) image after.
+2. Full master OTA → **no** false reboot (validates netTask keeps feeding while AsyncTCP streams on the same core).
+3. Full 16-unit reflash (`/reflash-units`) → no false reboot, no unit stranded in twiboot.
+4. Trigger an mDNS discovery scan + cluster fan-out on the live wall → no false reboot.
+
+- [ ] **Step 7: Open the PR**
+
+```bash
+git push -u origin feat/master-twdt-314
+gh pr create --base master --title "reliability(v2): TWDT app-task coverage (#314)" \
+  --body "Implements docs/superpowers/specs/2026-07-18-master-twdt-coverage-design.md. Closes #314. Bench-verified: hang→reboot, OTA/reflash/cluster no false reboot."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Timeout 30 s in `custom_sdkconfig` → Task 1. ✅
+- Subscribe all 5 tasks + loop-top feed → Task 3. ✅
+- Feed-inside long ops (reflash, self-test, boot-home) → Task 4. ✅
+- Cluster per-member + per-service-tick feed → Task 5. ✅
+- OTA/AsyncTCP left unwatched (deliberate) → covered by not touching it; noted in plan architecture. ✅
+- Error-code handling (ESP_OK vs log) → Task 2 returns `esp_err_t`, Task 3 logs `esp_err_to_name`. ✅
+- loopTask NOT subscribed → not in the task list; correct by omission. ✅
+- Config-guard pytest → Task 1. ✅
+- `TaskWatchdog.h` target-only, no native test → Task 2. ✅
+- Bench gate (hang, OTA, reflash, cluster) → Task 6. ✅
+- No CPU1 idle check → not added anywhere. ✅
+
+**Placeholder scan:** No TBD/TODO; every code step shows the exact insertion. Line numbers are marked "~" because they will drift as edits land — each is anchored to a named function or existing code snippet the implementer greps for.
+
+**Type consistency:** `wdtSubscribeSelf()` returns `esp_err_t` (Task 2) and is consumed as `esp_err_t e = wdtSubscribeSelf()` (Task 3). `wdtFeed()` returns void, called as a statement everywhere. Consistent.

--- a/docs/superpowers/specs/2026-07-18-master-twdt-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-18-master-twdt-coverage-design.md
@@ -61,6 +61,9 @@ Call `wdtFeed()` at the top of each of the 5 task loops, plus at these progress 
 - **self-test poll loops** and **boot-home step sequence** (displayTask) — feed per poll / per homing step.
 - **cluster fan-out** (clusterTask) — feed after each member's HTTP op in `clusterLeaderTick()`. Worst case is up to 8 members × 1.5 s plus a ~10 s rollout/follower-push finalize, which can approach 30 s in one tick, so per-member feeding is **required**, not conditional; it also preserves hang detection for the cluster transport path.
 - **`MDNS.queryService`** (netTask) — **no special handling**: it takes its own timeout arg (< 30 s), so the netTask loop-top `wdtFeed()` already covers it.
+- **shared `UnitBus.cpp` blocking waits called from displayTask** — feed inside their poll loops:
+  - `waitForDisplayToStop()` polls up to `SHOW_STUCK_TIMEOUT_MS` (currently == the 30 s TWDT window) and runs **twice** per `unitBusShowFrame()` (entry + exit), so a jammed flap can block ~60 s. Without a feed this reboot-loops on any stuck flap (a common mechanical failure the code otherwise survives). This constant must stay ≤ the TWDT timeout OR the loop must feed — it now feeds.
+  - `unitBusWaitBatchIdle()` waits `delay(1000)` + up to `REFLASH_BATCH_SETTLE_MS` (~16 s); combined with the trailing settle + reprobe in `runReflashJob` it can cross 30 s mid-reflash (strands a unit in twiboot). Feed inside the poll loop, and also feed before the trailing `unitBusProbe()` in `runReflashJob`.
 
 ### 5. Out of the subscribed set: OTA / AsyncTCP (deliberate)
 

--- a/docs/superpowers/specs/2026-07-18-master-twdt-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-18-master-twdt-coverage-design.md
@@ -43,43 +43,46 @@ The five FreeRTOS tasks (created in `Tasks.cpp` via `xTaskCreateStaticPinnedToCo
 
 Each `*TaskMain` calls `esp_task_wdt_add(NULL)` **once** at task start (after local init, before the loop), then `esp_task_wdt_reset()` at the **top of its loop**. clockTask's 1 Hz cadence and its bounded "stand down during a cluster commitAt render" wait (~seconds) are both far under 30 s, so it feeds safely every iteration.
 
-### 3. RAII pause guard — new header `TaskWatchdog.h`
+### 3. Feed-inside pattern — new header `TaskWatchdog.h`
 
-A scope object that unsubscribes the calling task from the TWDT for the duration of a long, self-bounded op, then re-subscribes:
+**Decision (revised after Codex cross-review):** feed the watchdog *inside* long ops rather than unsubscribing around them. The original unsubscribe (`esp_task_wdt_delete`/re-add) approach was rejected because it **blinds the dog to exactly the hang class #314 targets**: the long ops are I2C/network-bound, and this project has a documented history of the IDF I2C driver *wedging* (the 5.5 stale-read crash-loop). If a "self-bounded" transaction's own timeout fails, an unsubscribed task hangs forever undetected. Feeding inside keeps detection live — a wedge between two feed points still trips within ~30 s.
 
-- **ctor:** `esp_task_wdt_delete(NULL)`; record whether it was actually subscribed (delete returned `ESP_OK`).
-- **dtor:** `esp_task_wdt_add(NULL)` **only if** the ctor's delete succeeded — safe against early returns / exceptions, and never double-subscribes.
+`TaskWatchdog.h` holds two thin target-only helpers:
+- `wdtSubscribeSelf()` — `esp_task_wdt_add(NULL)`; treat `ESP_OK` as success, otherwise log `esp_err_to_name(err)`; never fatal. If idempotence matters, gate on `esp_task_wdt_status(NULL)` first.
+- `wdtFeed()` — thin wrapper on `esp_task_wdt_reset()` for the current task, called at loop tops and at progress points inside long loops.
 
-Target-only IDF glue. No pure logic → no native test (consistent with the project rule: host tests cover pure logic only, hardware glue is bench-verified).
+No pure logic → no native test (consistent with the project rule: host tests cover pure logic only, hardware glue is bench-verified).
 
-Rationale for unsubscribe-vs-feed: every long op below is **already individually time-bounded** by its own timeout (I2C hardware transaction timeouts; OTA's #313 per-chunk 30 s stall watchdog; cluster HTTP 1.5 s `esp_http_client` timeouts; `MDNS.queryService` timeout arg). The TWDT's job is to catch the *unbounded* hangs (event-loop deadlock, unreleased mutex, never-waking queue), which occur in the normal loop flow — not inside these bounded ops. So pausing the dog around a bounded op loses no meaningful protection while making false-reboot avoidance a one-line guard.
+### 4. Feed points
 
-### 4. Guard sites
+Call `wdtFeed()` at the top of each of the 5 task loops, plus at these progress points inside long ops so no single inter-feed span approaches 30 s:
 
-Wrap a `WdtPause` around each long op:
+- **`runReflashJob`** (displayTask) — feed at each per-batch (batch size 4) / per-unit boundary. A single unit page-write is I2C-bounded (ms); a driver wedge between boundaries still trips the dog.
+- **self-test poll loops** and **boot-home step sequence** (displayTask) — feed per poll / per homing step.
+- **cluster fan-out** (clusterTask) — feed after each member's HTTP op in `clusterLeaderTick()`. Worst case is up to 8 members × 1.5 s plus a ~10 s rollout/follower-push finalize, which can approach 30 s in one tick, so per-member feeding is **required**, not conditional; it also preserves hang detection for the cluster transport path.
+- **`MDNS.queryService`** (netTask) — **no special handling**: it takes its own timeout arg (< 30 s), so the netTask loop-top `wdtFeed()` already covers it.
 
-- **`runReflashJob`** (displayTask) — streams unit hex over I2C for tens of seconds; the critical one, a false reboot strands a unit in twiboot.
-- **self-test poll loops** and **boot-home `delay()`s** (displayTask).
-- **master OTA flash-write path** and **`MDNS.queryService` scan** (netTask).
-- **cluster #276 firmware-stream / finalize** (clusterTask) — guard **only if** measurement shows a single tick's fan-out can approach 30 s; otherwise each tick returns to the loop (and its `esp_task_wdt_reset()`) well within budget.
+### 5. Out of the subscribed set: OTA / AsyncTCP (deliberate)
 
-### 5. Error handling
+The master OTA write (`Update.write()` in the `/firmware/master` `onUpload` callback, `WebEndpoints.cpp`) runs in the **AsyncTCP task context**, not netTask (a deliberate v1-precedent async exception, noted in-code). AsyncTCP is not one of the 5 subscribed tasks, so the OTA write is **not** directly WDT-watched. This is acceptable: a stuck OTA is already caught by #313's per-chunk 30 s stall watchdog (aborted from `webEndpointsLoop` in netTask), and AsyncTCP starvation still trips the CPU0 idle check. We do not subscribe or feed the AsyncTCP task.
 
-`esp_task_wdt_add` returning `ESP_ERR_INVALID_STATE` (already subscribed) is logged and ignored — never fatal. The guard's conditional re-add prevents double-subscribe.
+## Resolved during cross-review (were open items)
 
-## Open implementation items (resolved during build, not blockers)
+1. **Arduino `loopTask`** does **not** need subscribing: `loop()` is only `tasksHeartbeatReport(); delay(5000)` — non-critical. `webEndpointsLoop()` runs in netTask (already subscribed), not loopTask.
+2. **clusterTask** feeding is **unconditional** (per §4) — a single tick's fan-out can approach 30 s, so it is not left to measurement.
 
-1. **Arduino `loopTask`** runs `webEndpointsLoop()` (incl. #313's OTA stall-abort). Determine whether the framework already WDT-subscribes `loopTask`; if it does real work unwatched, subscribe it as a 6th watched task (same add-at-start / reset-at-top pattern).
-2. **clusterTask worst-case tick** duration → decides whether guard site #4's cluster entry is needed.
+## Config guard (regression protection)
+
+The 30 s timeout lives in the tracked `custom_sdkconfig`, but the *effective* value is in the generated (gitignored) `sdkconfig`. Add a pytest under `tests/` — same spirit as `test_partition_table.py` / `test_custom_bootloader.py` — that asserts `firmware/v2/Master/platformio.ini`'s `custom_sdkconfig` carries `CONFIG_ESP_TASK_WDT_TIMEOUT_S=30` (and that `PANIC=y` is not disabled), so a future edit can't silently drop the override. Runs in CI.
 
 ## Bench verification (E2E gate — via VPN board access)
 
 1. Deliberately hang a subscribed task (behind a debug build flag) → board reboots within ~30 s; reset reason reported as TWDT.
-2. Full master OTA → **no** false reboot mid-flash.
-3. Full 16-unit reflash → no false reboot, no stranded unit.
-4. mDNS discovery scan + cluster fan-out on the live wall → no false reboot.
+2. Full master OTA → **no** false reboot. Specifically validates that netTask (core 0, subscribed) keeps getting scheduled to feed while AsyncTCP streams the image on the same core.
+3. Full 16-unit reflash → no false reboot, no stranded unit (validates the per-batch feeding in `runReflashJob`).
+4. mDNS discovery scan + cluster fan-out on the live wall → no false reboot (validates per-member feeding in `clusterLeaderTick`).
 
-Native tests: **not applicable** (pure IDF glue; no host-testable logic).
+Native tests: the config-guard pytest above. No host test for the IDF glue itself (pure target API; hardware glue is bench-verified per project rule).
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-07-18-master-twdt-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-18-master-twdt-coverage-design.md
@@ -1,0 +1,87 @@
+# Master TWDT app-task coverage (#314)
+
+**Status:** design approved 2026-07-18
+**Scope:** `firmware/v2/Master` only. Ships as a v2.0.1 reliability patch (post-v2.0.0), or folded into a "harden the wall" v2.1 arc.
+**Risk tier:** boot/reliability change → risk-tiered review always applies; bench E2E is the gate.
+
+## Motivation
+
+For an unattended wall-mounted display, a genuinely hung application task should auto-recover via reboot. The ESP-IDF Task Watchdog (TWDT) is already enabled but under-scoped: it watches only the **core-0 idle task** at 5 s with panic-reboot. That catches a core-0 task that *busy-spins* (starves idle), but **not** a task that blocks forever on a queue/mutex (it yields → idle keeps feeding the dog → hang undetected). The entire **display domain on core 1 is unwatched**.
+
+## Current state (`firmware/v2/Master`, generated `sdkconfig`)
+
+- `CONFIG_ESP_TASK_WDT_EN=y`, `CONFIG_ESP_TASK_WDT_INIT=y` — TWDT armed by the framework at boot.
+- `CONFIG_ESP_TASK_WDT_PANIC=y` — a timeout **reboots** (panic), not just warns.
+- `CONFIG_ESP_TASK_WDT_TIMEOUT_S=5`.
+- `CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU0=y`; **CPU1 not set**.
+
+Note: `Master/sdkconfig.defaults` is a **generated, gitignored** artifact — NOT the source of truth. Persistent sdkconfig overrides live in `platformio.ini`'s `custom_sdkconfig` (the same mechanism carrying `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE`).
+
+## Design
+
+### 1. Timeout → 30 s (config)
+
+Add to `custom_sdkconfig` in `firmware/v2/Master/platformio.ini`:
+
+```
+CONFIG_ESP_TASK_WDT_TIMEOUT_S=30
+```
+
+Overrides the framework's 5 s. Real hangs are still caught fast; 30 s is well clear of any legitimate blocking op. Keep `PANIC=y` and the existing CPU0 idle check. Do **not** enable `CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1` — explicit subscription of the two core-1 tasks already catches their busy-spins, so the idle-CPU1 check is redundant false-trip surface. Because `ESP_TASK_WDT_INIT=y`, the dog is armed at 30 s from boot; no runtime `esp_task_wdt_reconfigure()` is needed.
+
+### 2. Subscribe all 5 application tasks
+
+The five FreeRTOS tasks (created in `Tasks.cpp` via `xTaskCreateStaticPinnedToCore`):
+
+| task | core | cadence |
+|------|------|---------|
+| `displayTask` | 1 | event/queue-driven |
+| `clockTask` | 1 | 1 Hz tick |
+| `netTask` | 0 | periodic |
+| `mqttTask` | 0 | periodic |
+| `clusterTask` | 0 | periodic tick |
+
+Each `*TaskMain` calls `esp_task_wdt_add(NULL)` **once** at task start (after local init, before the loop), then `esp_task_wdt_reset()` at the **top of its loop**. clockTask's 1 Hz cadence and its bounded "stand down during a cluster commitAt render" wait (~seconds) are both far under 30 s, so it feeds safely every iteration.
+
+### 3. RAII pause guard — new header `TaskWatchdog.h`
+
+A scope object that unsubscribes the calling task from the TWDT for the duration of a long, self-bounded op, then re-subscribes:
+
+- **ctor:** `esp_task_wdt_delete(NULL)`; record whether it was actually subscribed (delete returned `ESP_OK`).
+- **dtor:** `esp_task_wdt_add(NULL)` **only if** the ctor's delete succeeded — safe against early returns / exceptions, and never double-subscribes.
+
+Target-only IDF glue. No pure logic → no native test (consistent with the project rule: host tests cover pure logic only, hardware glue is bench-verified).
+
+Rationale for unsubscribe-vs-feed: every long op below is **already individually time-bounded** by its own timeout (I2C hardware transaction timeouts; OTA's #313 per-chunk 30 s stall watchdog; cluster HTTP 1.5 s `esp_http_client` timeouts; `MDNS.queryService` timeout arg). The TWDT's job is to catch the *unbounded* hangs (event-loop deadlock, unreleased mutex, never-waking queue), which occur in the normal loop flow — not inside these bounded ops. So pausing the dog around a bounded op loses no meaningful protection while making false-reboot avoidance a one-line guard.
+
+### 4. Guard sites
+
+Wrap a `WdtPause` around each long op:
+
+- **`runReflashJob`** (displayTask) — streams unit hex over I2C for tens of seconds; the critical one, a false reboot strands a unit in twiboot.
+- **self-test poll loops** and **boot-home `delay()`s** (displayTask).
+- **master OTA flash-write path** and **`MDNS.queryService` scan** (netTask).
+- **cluster #276 firmware-stream / finalize** (clusterTask) — guard **only if** measurement shows a single tick's fan-out can approach 30 s; otherwise each tick returns to the loop (and its `esp_task_wdt_reset()`) well within budget.
+
+### 5. Error handling
+
+`esp_task_wdt_add` returning `ESP_ERR_INVALID_STATE` (already subscribed) is logged and ignored — never fatal. The guard's conditional re-add prevents double-subscribe.
+
+## Open implementation items (resolved during build, not blockers)
+
+1. **Arduino `loopTask`** runs `webEndpointsLoop()` (incl. #313's OTA stall-abort). Determine whether the framework already WDT-subscribes `loopTask`; if it does real work unwatched, subscribe it as a 6th watched task (same add-at-start / reset-at-top pattern).
+2. **clusterTask worst-case tick** duration → decides whether guard site #4's cluster entry is needed.
+
+## Bench verification (E2E gate — via VPN board access)
+
+1. Deliberately hang a subscribed task (behind a debug build flag) → board reboots within ~30 s; reset reason reported as TWDT.
+2. Full master OTA → **no** false reboot mid-flash.
+3. Full 16-unit reflash → no false reboot, no stranded unit.
+4. mDNS discovery scan + cluster fan-out on the live wall → no false reboot.
+
+Native tests: **not applicable** (pure IDF glue; no host-testable logic).
+
+## Out of scope
+
+- ESP-01 follower (`FollowerEsp01`) — single-core superloop on the ESP8266 SW watchdog (`ESP.wdtFeed()`), a different model. Follower logging visibility is #316.
+- Rescue app — minimal, separate reliability posture.

--- a/firmware/v2/Master/ClusterLeader.cpp
+++ b/firmware/v2/Master/ClusterLeader.cpp
@@ -31,6 +31,7 @@
 #include "MqttService.h"  // mqttNotificationActive — self-row re-show gate
 #include "ReflashPlan.h"
 #include "Tasks.h"
+#include "TaskWatchdog.h"
 
 #define CLUSTER_KEY_MEMBERS "clMembers"
 
@@ -1386,17 +1387,21 @@ void clusterLeaderTick() {
     String body;
     int status = clusterHttpRequest(items[i].url, items[i].body, body);
     applyMemberResult(items[i], status, body);
+    wdtFeed();  // #314: up to CLUSTER_MAX_MEMBERS blocking sends in one tick
   }
 
   // Fleet firmware convergence (#276) — after the fan-out so renders and
   // pings always get their tick before an upload chunk does.
   rolloutServiceTick();
+  wdtFeed();  // #314: a #276 firmware chunk write can block
   // On-demand ESP-01 firmware relay (#304) — mutually exclusive with the
   // auto-rollout above (each guards on the other's phase).
   followerPushServiceTick();
+  wdtFeed();  // #314: #304 relay chunk write
   // Pull one ESP-01 row's log into the fleet log (#318 E) — after the pushes
   // so a firmware stream always wins the tick over a log poll.
   followerLogPullTick();
+  wdtFeed();  // #314: #318E log poll
 }
 
 // Fills the status snapshot — leaderMutex HELD by the caller. The self

--- a/firmware/v2/Master/ClusterLeader.cpp
+++ b/firmware/v2/Master/ClusterLeader.cpp
@@ -1394,7 +1394,7 @@ void clusterLeaderTick() {
     String body;
     int status = clusterHttpRequest(items[i].url, items[i].body, body);
     applyMemberResult(items[i], status, body);
-    wdtFeed();  // #314: up to CLUSTER_MAX_MEMBERS blocking sends in one tick
+    wdtFeed();  // #314: bounds the blocking send (one member per tick, #320)
   }
 
   // Fleet firmware convergence (#276) — after the fan-out so renders and

--- a/firmware/v2/Master/TaskWatchdog.h
+++ b/firmware/v2/Master/TaskWatchdog.h
@@ -1,0 +1,16 @@
+#pragma once
+// ESP-IDF Task Watchdog helpers (#314). Target-only glue — no pure logic, so
+// no native test; verified on the bench (a hung subscribed task must reboot
+// within ~30 s, and OTA/reflash must NOT false-reboot). Feed-inside, never
+// unsubscribe: keeping the dog live during long ops is the whole point (a
+// wedged I2C transaction must still trip it).
+#include <esp_err.h>
+#include <esp_task_wdt.h>
+
+// Subscribe the CALLING task to the TWDT. Returns ESP_OK on success; the
+// caller logs esp_err_to_name(err) otherwise. Never aborts.
+inline esp_err_t wdtSubscribeSelf() { return esp_task_wdt_add(nullptr); }
+
+// Feed the TWDT for the calling task. Call at each task loop top AND at
+// progress points inside long ops so no inter-feed span approaches 30 s.
+inline void wdtFeed() { esp_task_wdt_reset(); }

--- a/firmware/v2/Master/Tasks.cpp
+++ b/firmware/v2/Master/Tasks.cpp
@@ -457,6 +457,11 @@ static void displayTaskMain(void*) {
   static UnitFacts busFacts[UNITS_AMOUNT];
 
   unitBusInit();
+  // Subscribe BEFORE the boot probe/reflash/boot-home block: those ops carry
+  // wdtFeed() calls that are silent no-ops for an unsubscribed task, and a
+  // wedged I2C transaction on the cold first scan must still trip the dog.
+  if (esp_err_t e = wdtSubscribeSelf(); e != ESP_OK)
+    SerialPrintf("wdt: display subscribe -> %s\n", esp_err_to_name(e));
   // Load-bearing pre-probe delay (v1 #88): probing earlier catches units
   // still in twiboot's boot window and the CHIPINFO read pins them there.
   delay(1500);
@@ -501,8 +506,6 @@ static void displayTaskMain(void*) {
 
   DisplayCommand cmd;
   int heartbeatSlot = 0;  // round-robin cursor for the scheduled poll (#310)
-  if (esp_err_t e = wdtSubscribeSelf(); e != ESP_OK)
-    SerialPrintf("wdt: display subscribe -> %s\n", esp_err_to_name(e));
   for (;;) {
     wdtFeed();
 #ifdef TWDT_HANG_TEST

--- a/firmware/v2/Master/Tasks.cpp
+++ b/firmware/v2/Master/Tasks.cpp
@@ -396,6 +396,7 @@ static void runReflashJob(DisplaySnapshot& local, UnitFacts* busFacts,
   // Final reprobe + health poll: published topology and fw grades are
   // execution-time truth (a failed/cancelled unit shows as bootloader and
   // stays pinned there — deliberate, see block comment).
+  wdtFeed();  // #314: no feed between the trailing settle and boot-home otherwise
   unitBusProbe(busFacts, UNITS_AMOUNT);
   pollHealthWithFreshness(busFacts);
   displayApplyUnitFacts(local, busFacts, UNITS_AMOUNT,

--- a/firmware/v2/Master/Tasks.cpp
+++ b/firmware/v2/Master/Tasks.cpp
@@ -202,6 +202,7 @@ static void runBootHomeSequence(DisplaySnapshot& local, UnitFacts* busFacts) {
   SerialPrintf("boot-home: staggering %d unit(s) in batches of %d\n", n,
                BOOT_HOME_BATCH_SIZE);
   for (int i = 0; i < n; i += BOOT_HOME_BATCH_SIZE) {
+    wdtFeed();  // #314: each batch waits on unit settle — keep the dog fed
     if (unitBusAbortRequested()) break;
     uint8_t batch[BOOT_HOME_BATCH_SIZE];
     int batchN = 0;
@@ -342,6 +343,7 @@ static void runReflashJob(DisplaySnapshot& local, UnitFacts* busFacts,
   uint8_t batch[REFLASH_BATCH_SIZE];
   int inBatch = 0;
   for (int k = 0; k < total; k++) {
+    wdtFeed();  // #314: I2C page-streaming is the longest displayTask op
     if (unitBusAbortRequested()) {
       cancelled = true;
       break;
@@ -403,6 +405,7 @@ static void runReflashJob(DisplaySnapshot& local, UnitFacts* busFacts,
   // render) would home every flashed unit at once — the #305 inrush #309
   // exists to prevent. Targets only the still-unhomed units; a cancel leaves
   // the abort flag set so this bails and the queued Stop broadcast-homes.
+  wdtFeed();  // #314: boot-home of just-flashed units
   runBootHomeSequence(local, busFacts);
   reflashProgressFinish(local.reflash, cancelled);
   snapshotPublish(local);  // gate reopens here
@@ -566,6 +569,7 @@ static void displayTaskMain(void*) {
             int badPolls = 0;
             uint32_t start = millis();
             while (millis() - start < SELF_TEST_TIMEOUT_MS) {
+              wdtFeed();  // #314: self-test polls the unit until it reports an outcome
               if (unitBusAbortRequested()) {
                 slot.outcome = SelfTestOutcome::Aborted;
                 break;

--- a/firmware/v2/Master/Tasks.cpp
+++ b/firmware/v2/Master/Tasks.cpp
@@ -465,6 +465,11 @@ static void displayTaskMain(void*) {
     SerialPrintf("wdt: display subscribe -> %s\n", esp_err_to_name(e));
   for (;;) {
     wdtFeed();
+#ifdef TWDT_HANG_TEST
+    // #314 bench: after 20 s of normal running, wedge displayTask forever so
+    // the TWDT must reboot within ~30 s. NEVER defined in a shipping build.
+    if (millis() > 20000) { for (;;) { /* no wdtFeed() → dog fires */ } }
+#endif
     // Timed wait: a real command preempts (display writes / reflash / Probe);
     // an idle timeout synthesizes one opportunistic heartbeat read.
     if (xQueueReceive(displayQueue, &cmd,

--- a/firmware/v2/Master/Tasks.cpp
+++ b/firmware/v2/Master/Tasks.cpp
@@ -27,6 +27,7 @@ void tasksSetUnitCountOverride(int count) {
 #include "MqttService.h"
 #include "StatusLed.h"
 #include "SystemStats.h"
+#include "TaskWatchdog.h"
 #include "UnitBus.h"
 #include "WebEndpoints.h"
 #include "WifiService.h"
@@ -457,7 +458,10 @@ static void displayTaskMain(void*) {
 
   DisplayCommand cmd;
   int heartbeatSlot = 0;  // round-robin cursor for the scheduled poll (#310)
+  if (esp_err_t e = wdtSubscribeSelf(); e != ESP_OK)
+    SerialPrintf("wdt: display subscribe -> %s\n", esp_err_to_name(e));
   for (;;) {
+    wdtFeed();
     // Timed wait: a real command preempts (display writes / reflash / Probe);
     // an idle timeout synthesizes one opportunistic heartbeat read.
     if (xQueueReceive(displayQueue, &cmd,
@@ -794,7 +798,10 @@ static void clockTaskMain(void*) {
   SerialPrintf("clockTask up on core %d\n", xPortGetCoreID());
   TickType_t lastWake = xTaskGetTickCount();
   String lastQueued;  // in-flight dedup, see ClockPolicy.h contract
+  if (esp_err_t e = wdtSubscribeSelf(); e != ESP_OK)
+    SerialPrintf("wdt: clock subscribe -> %s\n", esp_err_to_name(e));
   for (;;) {
+    wdtFeed();
     vTaskDelayUntil(&lastWake, pdMS_TO_TICKS(1000));
 
     DisplaySnapshot snap = displaySnapshotGet();
@@ -905,7 +912,10 @@ struct NetTaskContext {
 static void netTaskMain(void* arg) {
   SerialPrintf("netTask up on core %d\n", xPortGetCoreID());
   auto* ctx = static_cast<NetTaskContext*>(arg);
+  if (esp_err_t e = wdtSubscribeSelf(); e != ESP_OK)
+    SerialPrintf("wdt: net subscribe -> %s\n", esp_err_to_name(e));
   for (;;) {
+    wdtFeed();
     wifiServiceTick();
     webEndpointsLoop(*ctx->settings, *ctx->store);
     clusterFollowerServiceTick(*ctx->store);  // #272: decay + NVS + renders
@@ -923,7 +933,10 @@ static void netTaskMain(void* arg) {
 static void mqttTaskMain(void*) {
   SerialPrintf("mqttTask up on core %d\n", xPortGetCoreID());
   MqttInboxMessage msg;
+  if (esp_err_t e = wdtSubscribeSelf(); e != ESP_OK)
+    SerialPrintf("wdt: mqtt subscribe -> %s\n", esp_err_to_name(e));
   for (;;) {
+    wdtFeed();
     while (xQueueReceive(mqttInbox, &msg, 0) == pdTRUE) {
       mqttServiceHandleInbox(msg);
     }
@@ -938,7 +951,10 @@ static void mqttTaskMain(void*) {
 // (ClusterLeader.cpp); disabled clusters make it a no-op read.
 static void clusterTaskMain(void*) {
   SerialPrintf("clusterTask up on core %d\n", xPortGetCoreID());
+  if (esp_err_t e = wdtSubscribeSelf(); e != ESP_OK)
+    SerialPrintf("wdt: cluster subscribe -> %s\n", esp_err_to_name(e));
   for (;;) {
+    wdtFeed();
     clusterLeaderTick();
     vTaskDelay(pdMS_TO_TICKS(100));
   }

--- a/firmware/v2/Master/UnitBus.cpp
+++ b/firmware/v2/Master/UnitBus.cpp
@@ -15,6 +15,7 @@
 #include "HelpersSerialHandling.h"
 #include "MaintenancePolicy.h"
 #include "SplitFlapProtocol.h"
+#include "TaskWatchdog.h"  // wdtFeed() (#314)
 #include "TwibootProtocol.h"
 #include "UnitProtocolHelpers.h"
 
@@ -35,7 +36,10 @@ static constexpr uint32_t UNIT_BUS_FREQ_HZ = 100000;
 // receiveEvent ISR has time to flip its pending*Response flag.
 static constexpr uint32_t UNIT_RESPONSE_SETTLE_MS = 2;
 // How long waitForDisplayToStop() keeps polling before assuming a unit is
-// physically stuck (status byte pegged at 1) and moving on.
+// physically stuck (status byte pegged at 1) and moving on. This and any
+// other display stuck-timeout must stay <= the TWDT timeout, OR the poll
+// loop must feed the watchdog itself (it does, #314) — a jammed flap is a
+// mechanical condition this code deliberately survives, not a reboot cause.
 static constexpr uint32_t SHOW_STUCK_TIMEOUT_MS = 30000;
 
 static int toI2cAddress(int unitIndex) {
@@ -290,6 +294,7 @@ static void waitForDisplayToStop(const UnitFacts* facts, int width) {
   uint32_t waitStart = millis();
   uint32_t lastWaitLog = 0;
   while (isDisplayMoving(facts, width)) {
+    wdtFeed();  // #314: feed the TWDT through a legitimate stuck-flap wait
     if (abortRequested.load()) {
       SerialPrintln(F("Display-stop wait aborted by /stop"));
       break;
@@ -707,6 +712,7 @@ void unitBusWaitBatchIdle(const uint8_t* addrs, int count,
   delay(1000);  // let CMD_REBOOT take effect before polling
   uint32_t start = millis();
   while (millis() - start < timeoutMs) {
+    wdtFeed();  // #314: feed the TWDT through the batch-settle poll
     bool allIdle = true;
     for (int k = 0; k < count; k++) {
       // checkIfMoving takes a unit INDEX; addrs carry bus addresses.

--- a/firmware/v2/Master/WifiPolicy.h
+++ b/firmware/v2/Master/WifiPolicy.h
@@ -8,15 +8,24 @@
 // and feeds this step function from netTask; everything decision-shaped is
 // natively tested (test/test_wifi_policy).
 //
-// Once Connected the machine is parked for good: link drops belong to the
-// SDK's auto-reconnect (WiFi.setAutoReconnect(true)), never a portal
-// re-entry.
+// Once Connected, brief link drops belong to the SDK's auto-reconnect
+// (WiFi.setAutoReconnect(true)) and never re-open the portal. But that path
+// is known to wedge on the ESP32-S3 after an AP power-cycle (esp_wifi +
+// WiFi.persistent(false) leaves nothing to un-stick the STA), stranding the
+// board off-network until a manual power cycle (#328). So a bounded reconnect
+// watchdog reboots after a sustained outage — the same "router may just have
+// been down" retry the portal-timeout path already uses. We reboot; we still
+// never re-open the portal.
 
 #include <stdint.h>
 
 // v1 timings verbatim (user decision 2026-07-09 on #58).
 static const uint32_t WIFI_JOIN_TIMEOUT_MS = 30000UL;
 static const uint32_t WIFI_PORTAL_TIMEOUT_MS = 300000UL;
+// #328: continuous Connected-phase link loss tolerated before a recovery
+// reboot. Long enough that the SDK auto-reconnect owns transient blips; short
+// enough that an AP-reboot wedge self-heals in ~1.5 min instead of never.
+static const uint32_t WIFI_RECONNECT_TIMEOUT_MS = 90000UL;
 
 enum class WifiPhase : uint8_t { Boot, Joining, Portal, Connected };
 
@@ -32,6 +41,10 @@ enum class WifiAction : uint8_t {
 struct WifiPolicyState {
   WifiPhase phase = WifiPhase::Boot;
   uint32_t deadlineMs = 0;  // end of the current join/portal window
+  // #328: millis() at which a Connected-phase link loss began; 0 = link up
+  // (or not yet tracking). The reconnect watchdog fires on continuous
+  // downtime, so any link-up tick clears it.
+  uint32_t linkDownSinceMs = 0;
 };
 
 // Rollover-safe "now reached deadline": valid while the window length stays
@@ -89,9 +102,28 @@ static inline WifiAction wifiPolicyStep(WifiPolicyState& st, uint32_t nowMs,
     case WifiPhase::Connected:
       // The portal page doubles as a "move to another network" page from
       // the LAN: a validated submission here persists + reboots exactly
-      // like a portal one. Link drops still never re-open the portal.
+      // like a portal one. It wins even mid-outage.
       if (portalSubmitted) {
         return WifiAction::SaveAndReboot;
+      }
+      // Healthy link: clear any armed outage clock and stay parked — the SDK
+      // auto-reconnect owns transient drops.
+      if (linkUp) {
+        st.linkDownSinceMs = 0;
+        return WifiAction::None;
+      }
+      // Link is down. Arm the outage clock on the first down tick (0 is the
+      // sentinel for "up"; nudge an exact-0 timestamp to 1 so it never reads
+      // as unarmed). Reboot only on CONTINUOUS downtime past the window —
+      // any link-up tick above resets it. #328: this un-wedges the S3's
+      // auto-reconnect after an AP power-cycle. We reboot; never re-open the
+      // portal.
+      if (st.linkDownSinceMs == 0) {
+        st.linkDownSinceMs = nowMs ? nowMs : 1;
+      }
+      if (wifiDeadlineReached(nowMs,
+                              st.linkDownSinceMs + WIFI_RECONNECT_TIMEOUT_MS)) {
+        return WifiAction::Reboot;
       }
       return WifiAction::None;
 

--- a/firmware/v2/Master/WifiService.cpp
+++ b/firmware/v2/Master/WifiService.cpp
@@ -260,7 +260,12 @@ void wifiServiceTick() {
         break;
       }
       case WifiAction::Reboot:
-        scheduleRestart(F("setup portal timed out — retrying stored WiFi"));
+        // Same action, two origins: a Connected-phase Reboot is the #328
+        // reconnect watchdog (link wedged after an AP power-cycle); otherwise
+        // it is the portal-timeout retry. Distinguish them in the log.
+        scheduleRestart(policy.phase == WifiPhase::Connected
+                            ? F("WiFi link lost too long — rebooting to re-join (#328)")
+                            : F("setup portal timed out — retrying stored WiFi"));
         break;
       case WifiAction::None:
         break;

--- a/firmware/v2/Master/WifiService.cpp
+++ b/firmware/v2/Master/WifiService.cpp
@@ -3,6 +3,7 @@
 #include <DNSServer.h>
 #include <ESPmDNS.h>
 #include <WiFi.h>
+#include <atomic>
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 
@@ -49,6 +50,33 @@ struct StageLock {
   StageLock& operator=(const StageLock&) = delete;
 };
 
+// #328 supplement — event-driven STA re-kick, on top of the policy watchdog.
+// WiFi.setAutoReconnect(true) is supposed to own reconnection, but its esp_wifi
+// handler can give up or wedge after an AP power-cycle. This re-issues a
+// connect on every STA disconnect while we intend to be online, throttled so it
+// neither floods the log nor fights the driver's own retries. It recovers most
+// drops in seconds; the WifiPolicy watchdog reboot stays the guaranteed backstop
+// if even this cannot. Runs in the Arduino event task (not netTask): the reads
+// "do we want the link up?" answer from an atomic that netTask publishes each
+// tick — same cross-task discipline as the stageMutex-guarded fields, without a
+// lock the driver's event task must never block on.
+static const uint32_t WIFI_RECONNECT_KICK_MS = 5000;
+static uint32_t lastReconnectKickMs = 0;                 // event-task-private
+static std::atomic<bool> staReconnectWanted{false};      // netTask -> event task
+
+static void onWifiStaEvent(WiFiEvent_t event, WiFiEventInfo_t info) {
+  if (event != ARDUINO_EVENT_WIFI_STA_DISCONNECTED) return;
+  // Only re-kick when a live association is what we want (Connected, no reboot
+  // pending). Portal/Boot/Joining leave STA retries to WifiPolicy.
+  if (!staReconnectWanted.load(std::memory_order_relaxed)) return;
+  uint32_t now = millis();
+  if (now - lastReconnectKickMs < WIFI_RECONNECT_KICK_MS) return;
+  lastReconnectKickMs = now;
+  SerialPrintf("wifi: STA disconnected (reason %u) — re-issuing connect\n",
+               (unsigned)info.wifi_sta_disconnected.reason);
+  WiFi.reconnect();
+}
+
 void wifiServiceInit(AsyncWebServer& server, MasterSettings& settings,
                      SettingsStore& store, const String& effectiveDeviceName) {
   stageMutex = xSemaphoreCreateMutex();
@@ -60,6 +88,8 @@ void wifiServiceInit(AsyncWebServer& server, MasterSettings& settings,
   liveSettings = &settings;
   settingsStore = &store;
   deviceName = effectiveDeviceName;
+  // #328: supplement setAutoReconnect with the event-driven re-kick above.
+  WiFi.onEvent(onWifiStaEvent, ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
 }
 
 void wifiStagePortalConfig(const String& ssid, const String& pass) {
@@ -276,4 +306,10 @@ void wifiServiceTick() {
     Serial.flush();
     ESP.restart();
   }
+
+  // #328: publish the event-task re-kick gate (atomic hand-off) — we only want
+  // the STA-disconnect handler firing while Connected and not mid-reboot.
+  staReconnectWanted.store(
+      policy.phase == WifiPhase::Connected && !restartPending,
+      std::memory_order_relaxed);
 }

--- a/firmware/v2/Master/platformio.ini
+++ b/firmware/v2/Master/platformio.ini
@@ -51,6 +51,9 @@ board_upload.arduino.boot_app0 = 0x19000
 ; artifact in at 0x0.
 custom_sdkconfig =
   CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y
+  ; TWDT (#314): 30 s app-task watchdog. 5 s (framework default) is too tight
+  ; for legitimate long ops; PANIC + CPU0 idle check stay as framework defaults.
+  CONFIG_ESP_TASK_WDT_TIMEOUT_S=30
 ; The hybrid compile rebuilds every IDF managed component, and several we
 ; will never use fail to build standalone (esp-modbus config static-assert,
 ; libhelix ARM asm on Xtensa). Drop the media/cloud/radio extras; mDNS,

--- a/firmware/v2/Master/platformio.ini
+++ b/firmware/v2/Master/platformio.ini
@@ -125,6 +125,9 @@ build_flags =
   ; Shared master<->unit I2C protocol header — Phase 1 speaks the v1
   ; protocol to the v1 units, so the contract lives in v1's tree.
   -I ../shared
+  ; #314 bench only — wedge displayTask ~20 s after boot to prove the TWDT
+  ; reboot. Never enable in a shipping/OTA build. Uncomment to bench:
+  ; -D TWDT_HANG_TEST
 
 ; Host-side unit tests for pure sketch logic (no Arduino hardware deps).
 ; Mirrors firmware/v1/ESPMaster [env:native] — same ArduinoFake caveats

--- a/firmware/v2/Master/test/test_wifi_policy/test_main.cpp
+++ b/firmware/v2/Master/test/test_wifi_policy/test_main.cpp
@@ -123,16 +123,73 @@ static void test_config_submitted_while_connected_saves_and_reboots() {
                     wifiPolicyStep(st, 90000, true, true, true));
 }
 
-static void test_link_drop_after_connect_never_reopens_portal() {
-  // v1 parity: WiFi.setAutoReconnect(true) owns reconnection; the policy
-  // stays parked in Connected no matter what the link reports.
-  WifiPolicyState st;
+// Convenience: reach Connected phase with a link, ready for drop tests.
+static void connect(WifiPolicyState& st) {
   quietStep(st, 1000, true);
   wifiPolicyStep(st, 2000, true, true, false);  // -> Connected
-  TEST_ASSERT_EQUAL(WifiAction::None, quietStep(st, 500000, true));
+}
+
+static void test_brief_link_drop_after_connect_does_not_reboot() {
+  // The SDK auto-reconnect owns transient drops: within the reconnect window
+  // the policy stays parked in Connected, no reboot.
+  WifiPolicyState st;
+  connect(st);
   TEST_ASSERT_EQUAL(WifiAction::None,
-                    quietStep(st, 500000 + WIFI_PORTAL_TIMEOUT_MS, true));
+                    wifiPolicyStep(st, 2000 + WIFI_RECONNECT_TIMEOUT_MS - 1,
+                                   false, true, false));
   TEST_ASSERT_EQUAL(WifiPhase::Connected, st.phase);
+}
+
+static void test_sustained_link_drop_after_connect_reboots() {
+  // #328: a continuous outage past the reconnect window means the SDK is
+  // wedged — reboot to re-run the join. Never re-open the portal.
+  WifiPolicyState st;
+  connect(st);
+  // First down tick arms the outage clock (link went down at t=2000).
+  TEST_ASSERT_EQUAL(WifiAction::None, quietStep(st, 3000, true));
+  WifiAction a =
+      wifiPolicyStep(st, 3000 + WIFI_RECONNECT_TIMEOUT_MS, false, true, false);
+  TEST_ASSERT_EQUAL(WifiAction::Reboot, a);
+  TEST_ASSERT_EQUAL(WifiPhase::Connected, st.phase);  // reboot, not portal
+}
+
+static void test_link_recovery_resets_reconnect_watchdog() {
+  // A drop that recovers before the window must not carry over: the outage
+  // clock resets on link-up, so a later brief drop starts fresh.
+  WifiPolicyState st;
+  connect(st);
+  quietStep(st, 3000, true);                                  // down, arm clock
+  TEST_ASSERT_EQUAL(WifiAction::None,
+                    wifiPolicyStep(st, 60000, true, true, false));  // recovered
+  // A fresh drop 89 s later is still within a new window — no reboot.
+  quietStep(st, 61000, true);
+  TEST_ASSERT_EQUAL(WifiAction::None,
+                    wifiPolicyStep(st, 61000 + WIFI_RECONNECT_TIMEOUT_MS - 1,
+                                   false, true, false));
+  TEST_ASSERT_EQUAL(WifiPhase::Connected, st.phase);
+}
+
+static void test_reconnect_watchdog_survives_millis_rollover() {
+  // Outage clock armed just before the uint32 wrap; the deadline lands past
+  // it. Signed-difference math must hold the window across the seam.
+  WifiPolicyState st;
+  connect(st);
+  const uint32_t nearWrap = 0xFFFFFF00u;
+  TEST_ASSERT_EQUAL(WifiAction::None, quietStep(st, nearWrap, true));  // arm
+  const uint32_t afterWrap = nearWrap + WIFI_RECONNECT_TIMEOUT_MS;     // wrapped
+  TEST_ASSERT_TRUE(afterWrap < nearWrap);                             // sanity
+  TEST_ASSERT_EQUAL(WifiAction::None, quietStep(st, afterWrap - 1, true));
+  TEST_ASSERT_EQUAL(WifiAction::Reboot, quietStep(st, afterWrap, true));
+}
+
+static void test_config_submitted_while_disconnected_still_saves_and_reboots() {
+  // A "move to another network" submission must win even mid-outage — the
+  // reconnect watchdog must not shadow a staged credential change.
+  WifiPolicyState st;
+  connect(st);
+  quietStep(st, 3000, true);  // link down, watchdog armed
+  TEST_ASSERT_EQUAL(WifiAction::SaveAndReboot,
+                    wifiPolicyStep(st, 4000, false, true, true));
 }
 
 // --- millis() rollover -----------------------------------------------------------
@@ -167,7 +224,11 @@ int main(int, char**) {
   RUN_TEST(test_portal_timeout_reboots_to_retry);
   RUN_TEST(test_portal_submission_wins_over_simultaneous_timeout);
   RUN_TEST(test_config_submitted_while_connected_saves_and_reboots);
-  RUN_TEST(test_link_drop_after_connect_never_reopens_portal);
+  RUN_TEST(test_brief_link_drop_after_connect_does_not_reboot);
+  RUN_TEST(test_sustained_link_drop_after_connect_reboots);
+  RUN_TEST(test_link_recovery_resets_reconnect_watchdog);
+  RUN_TEST(test_reconnect_watchdog_survives_millis_rollover);
+  RUN_TEST(test_config_submitted_while_disconnected_still_saves_and_reboots);
   RUN_TEST(test_join_timeout_survives_millis_rollover);
   return UNITY_END();
 }

--- a/firmware/v2/Master/tests/test_task_watchdog_config.py
+++ b/firmware/v2/Master/tests/test_task_watchdog_config.py
@@ -1,0 +1,42 @@
+"""TWDT config guard (#314).
+
+The effective ESP_TASK_WDT_TIMEOUT_S lives in the generated (gitignored)
+sdkconfig; the tracked source is platformio.ini's custom_sdkconfig. This
+test pins that source so a future edit can't silently drop the 30 s override
+or the panic-reboot behaviour the unattended wall depends on.
+
+Run with:
+    pytest tests/
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+PROJECT_DIR = pathlib.Path(__file__).resolve().parent.parent
+INI_PATH = PROJECT_DIR / "platformio.ini"
+
+
+def custom_sdkconfig_lines() -> list[str]:
+    """Return the entries of the [env:master] custom_sdkconfig block."""
+    text = INI_PATH.read_text()
+    m = re.search(r"^custom_sdkconfig\s*=\s*$(.*?)^\S", text,
+                  re.MULTILINE | re.DOTALL)
+    assert m, "custom_sdkconfig block not found in platformio.ini"
+    lines = []
+    for raw in m.group(1).splitlines():
+        stripped = raw.strip()
+        if stripped and not stripped.startswith(";"):
+            lines.append(stripped)
+    return lines
+
+
+def test_task_wdt_timeout_is_30s():
+    assert "CONFIG_ESP_TASK_WDT_TIMEOUT_S=30" in custom_sdkconfig_lines()
+
+
+def test_task_wdt_panic_not_disabled():
+    # PANIC defaults on (framework) and must not be turned off here — a
+    # timeout must reboot, not just warn.
+    assert "CONFIG_ESP_TASK_WDT_PANIC=n" not in custom_sdkconfig_lines()


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-07-18-master-twdt-coverage-design.md`. Closes #314.

## What
Subscribes all 5 master FreeRTOS tasks to the ESP-IDF Task Watchdog and bumps the timeout 5 s → 30 s, so a genuinely hung app task auto-reboots the unattended wall — without false-tripping during legitimate long ops.

- `custom_sdkconfig`: `CONFIG_ESP_TASK_WDT_TIMEOUT_S=30` (+ regression-guard pytest); PANIC + CPU0-idle kept, CPU1-idle not added.
- `TaskWatchdog.h`: `wdtSubscribeSelf()` / `wdtFeed()`.
- All 5 tasks (display, clock / net, mqtt, cluster) subscribe once + feed at loop top.
- **Feed-inside, never unsubscribe** — keeps the dog live during long ops so a wedged I2C transaction is still caught. Feed points: `runReflashJob` per-unit + trailing probe, boot-home batches, self-test poll, cluster fan-out per-member + service ticks, and the two shared `UnitBus.cpp` blocking waits (`waitForDisplayToStop`, `unitBusWaitBatchIdle`).
- OTA write runs in the AsyncTCP task → deliberately unwatched (covered by #313 stall-abort + CPU0 idle).
- Compile-guarded `TWDT_HANG_TEST` bench hook (flag committed OFF).

## Design provenance
Design cross-reviewed by Codex (flipped the strategy from unsubscribe → feed-inside; fixed OTA/AsyncTCP task attribution). Whole-branch cpp-review caught two shared-helper false-reboot gaps (jammed-flap reboot loop; reflash-settle overrun) — both fixed in `a632a8e`.

## Test plan
- [x] `pio run` green; `pio test -e native` 725/725; config-guard pytest green.
- [ ] **Bench (E2E gate — required before merge):**
  - [ ] Build with `-D TWDT_HANG_TEST` → board reboots ~30 s after boot, reset reason = TWDT; reflash clean image after.
  - [ ] Full master OTA → no false reboot (netTask keeps feeding while AsyncTCP streams same-core).
  - [ ] Full 16-unit reflash → no false reboot, no unit stranded in twiboot.
  - [ ] Deliberately stall/jam a unit during a ShowText → board keeps running (logs stuck, does NOT reboot-loop).
  - [ ] mDNS scan + cluster fan-out on the live wall → no false reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)