### PR TITLE
Headless mode for unit-less S3 masters (#329) + cluster UI/vitals fixes

### DIFF
--- a/firmware/v2/Master/ClusterDigest.h
+++ b/firmware/v2/Master/ClusterDigest.h
@@ -178,13 +178,21 @@ inline String clusterStatusJson(const ClusterLeaderStatus& st) {
 // own rank by matching its `you` index against this list.
 inline String clusterSuccessorList(const ClusterLeaderStatus& st) {
   String out;
-  for (int i = 0; i < st.memberCount; i++) {
-    if (st.members[i].host.length() == 0) continue;  // the leader's own row
-    if (clusterMemberPlatForeign(st.members[i].plat, CLUSTER_LEADER_PLAT)) {
-      continue;  // ESP-01 / foreign board — never a takeover candidate
+  // Two passes so a width-0 warm-standby backup (#333 — no row of its own to
+  // lose, spare capacity) outranks the rendering rows: preferred successors
+  // (rank 0) first, then the rendering S3 followers, each in table order.
+  for (int pass = 0; pass < 2; pass++) {
+    const bool wantBackup = (pass == 0);
+    for (int i = 0; i < st.memberCount; i++) {
+      const ClusterLeaderMemberStatus& m = st.members[i];
+      if (m.host.length() == 0) continue;  // the leader's own row
+      if (clusterMemberPlatForeign(m.plat, CLUSTER_LEADER_PLAT)) {
+        continue;  // ESP-01 / foreign board — never a takeover candidate
+      }
+      if ((m.width == 0) != wantBackup) continue;  // this pass's tier only
+      if (out.length()) out += ',';
+      out += String(i);
     }
-    if (out.length()) out += ',';
-    out += String(i);
   }
   return out;
 }

--- a/firmware/v2/Master/ClusterDigest.h
+++ b/firmware/v2/Master/ClusterDigest.h
@@ -201,7 +201,7 @@ inline String clusterBuildDigest(uint32_t gen, const String& leaderName,
                                  const String& leaderHost,
                                  const String& tableSpec, const String* rows,
                                  int rowCount, const ClusterLeaderStatus& st,
-                                 uint32_t holdMs = 0) {
+                                 uint32_t holdMs = 0, const String& mode = "") {
   String out;
   out.reserve(256 + rowCount * 40 + st.memberCount * 200);
   out += "{\"gen\":";
@@ -221,6 +221,8 @@ inline String clusterBuildDigest(uint32_t gen, const String& leaderName,
   appendJsonString(out, clusterSuccessorList(st));
   out += ",\"hold\":";
   out += String((unsigned long)holdMs);  // #321: 0 unless a reboot is imminent
+  out += ",\"mode\":";  // #337: leader's active deviceMode — a promoted
+  appendJsonString(out, mode);  // successor adopts it so the wall mode survives
   out += ",\"status\":";
   out += clusterStatusJson(st);
   out += '}';

--- a/firmware/v2/Master/ClusterFollower.cpp
+++ b/firmware/v2/Master/ClusterFollower.cpp
@@ -11,6 +11,7 @@
 #include "ClusterDigest.h"  // promote transform + digest field extraction
 #include "ClusterHmac.h"  // cluster-wire auth: key storage + verify (#313 follow-on)
 #include "ClusterLeader.h"  // clusterLeaderStageConfig — the promote handoff
+#include "WebEndpoints.h"   // #337: webMqttApplyMode — adopt cluster mode on promote
 #include "DisplayCommand.h"
 #include "HelpersSerialHandling.h"
 #include "ReflashPlan.h"
@@ -27,6 +28,7 @@
 // follower reboot; written only when the table actually changes.
 #define CLUSTER_KEY_TABLE       "clTable"
 #define CLUSTER_KEY_SELF_INDEX  "clSelfIdx"
+#define CLUSTER_KEY_MODE        "clMode"    // #337: cluster deviceMode for promote
 // Cluster-wire auth key (#313 follow-on): the 64-char hex the leader minted
 // at join. Persisted so a rebooted follower keeps enforcing in Grace.
 #define CLUSTER_KEY_HMAC        "clHmacKey"
@@ -73,6 +75,8 @@ static String digestRaw;
 static uint32_t digestReceivedMs = 0;
 static String digestTable;
 static int digestSelfIndex = -1;
+static String digestMode;  // #337: leader's active deviceMode from the digest —
+                           // a promoted successor adopts it so the wall mode survives
 static bool tableDirty = false;
 // #321 ranked auto-takeover: this board's rank in the leader's `succ` list
 // (-1 = not a designated successor), and the deadline until which an announced
@@ -109,6 +113,7 @@ void clusterFollowerInit(SettingsStore& store) {
   memberRow = store.getInt(CLUSTER_KEY_ROW, 0);
   digestTable = store.getString(CLUSTER_KEY_TABLE, "");
   digestSelfIndex = store.getInt(CLUSTER_KEY_SELF_INDEX, -1);
+  digestMode = store.getString(CLUSTER_KEY_MODE, "");  // #337
   hmacKeyHex = store.getString(CLUSTER_KEY_HMAC, "");
   hmacKeyValid = clusterKeyFromHex(hmacKeyHex, hmacKey);
   if (!hmacKeyValid) hmacKeyHex = "";
@@ -135,6 +140,7 @@ void clusterFollowerServiceTick(SettingsStore& store) {
   bool persistTable = false;
   String persistTableSpec;
   int persistSelfIndex = -1;
+  String persistModeVal;  // #337: cluster mode, written with the table
   bool persistTs = false;
   uint64_t persistTsVal = 0;
 
@@ -171,6 +177,7 @@ void clusterFollowerServiceTick(SettingsStore& store) {
       persistTable = true;
       persistTableSpec = digestTable;
       persistSelfIndex = digestSelfIndex;
+      persistModeVal = digestMode;  // #337
     }
     // Coarse replay-mark persist: fold the current mark into a membership
     // write when one is pending, else stage a standalone mark write. On a
@@ -226,9 +233,11 @@ void clusterFollowerServiceTick(SettingsStore& store) {
     if (persistTableSpec.length() > 0) {
       store.putString(CLUSTER_KEY_TABLE, persistTableSpec);
       store.putInt(CLUSTER_KEY_SELF_INDEX, persistSelfIndex);
+      store.putString(CLUSTER_KEY_MODE, persistModeVal);  // #337
     } else {
       store.remove(CLUSTER_KEY_TABLE);
       store.remove(CLUSTER_KEY_SELF_INDEX);
+      store.remove(CLUSTER_KEY_MODE);
     }
   }
 
@@ -386,6 +395,14 @@ bool clusterFollowerHandlePing(const String& digest, int youIndex,
       digestSelfIndex = youIndex;
       tableDirty = true;
     }
+    // #337: the leader's active deviceMode. Kept fresh in RAM every digest so a
+    // live promote adopts the current mode; persisted with the promote-critical
+    // block (below) so a reboot-then-promote still has a reasonable mode.
+    String mode = clusterExtractJsonString(digest, "mode");
+    if (mode.length() > 0 && mode != digestMode) {
+      digestMode = mode;
+      tableDirty = true;  // rides the existing promote-critical NVS write
+    }
   }
   return true;
 }
@@ -469,7 +486,7 @@ static bool promoteGatePasses(bool autoPath) {
 
 static ClusterPromoteVerdict clusterFollowerPromoteImpl(bool autoPath) {
   if (clusterMutex == nullptr) return {500, "cluster service not running"};
-  String tableSpec, oldLeaderHost;
+  String tableSpec, oldLeaderHost, mode;
   int selfIndex;
   {
     ClusterLock lock;
@@ -485,6 +502,7 @@ static ClusterPromoteVerdict clusterFollowerPromoteImpl(bool autoPath) {
     tableSpec = digestTable;
     selfIndex = digestSelfIndex;
     oldLeaderHost = leaderHost;
+    mode = digestMode;  // #337: adopt the cluster mode after taking over
   }
 
   // Outside the lock: the leader module's calls take LeaderLock — the two
@@ -511,6 +529,11 @@ static ClusterPromoteVerdict clusterFollowerPromoteImpl(bool autoPath) {
     followerLeaveLocked();
   }
   clusterLeaderStageConfig(newSpec);  // pre-validated: cannot fail
+  // #337: adopt the cluster's active display mode so the wall resumes as-is.
+  // A clock especially needs THIS board's deviceMode=clock for its clockTask
+  // to drive the grid; without this the successor falls back to its own NVS
+  // mode and the wall changes. Outside every lock (WebStateLock only).
+  if (mode.length() > 0) webMqttApplyMode(mode);
   SerialPrintln(String("cluster: ") +
                 (autoPath ? "AUTO-PROMOTED" : "PROMOTED") +
                 " — taking over the wall as leader (" + newSpec + ")");

--- a/firmware/v2/Master/ClusterLayout.h
+++ b/firmware/v2/Master/ClusterLayout.h
@@ -71,12 +71,18 @@ inline ClusterVerdict validateMemberTable(const ClusterMemberTable& table,
   int maxRow = -1;
   for (int i = 0; i < table.count; i++) {
     const ClusterMemberDef& m = table.members[i];
-    if (m.width == 0) return {false, "Member width must be at least 1"};
     if (m.row >= CLUSTER_MAX_MEMBERS) {
       return {false, "Row index beyond the member cap"};
     }
+    // #333 warm-standby: a width-0 member is OFF-GRID — it keeps membership
+    // (pings, digest, promote rank) but claims no columns, so it never tiles
+    // a row. Its row/col are ignored; skip it from every grid computation.
+    if (m.width == 0) continue;
     if (m.row > maxRow) maxRow = m.row;
   }
+  // #333: at least one member must render — an all-off-grid table (every
+  // member width 0) would "enable" a cluster that shows nothing anywhere.
+  if (maxRow == -1) return {false, "No rendering members (all off-grid)"};
 
   // Tile each row left to right: every cursor position must be the start
   // of exactly one member span (coincident mirror twins advance together,
@@ -84,7 +90,7 @@ inline ClusterVerdict validateMemberTable(const ClusterMemberTable& table,
   for (int r = 0; r <= maxRow; r++) {
     int inRow = 0;
     for (int i = 0; i < table.count; i++) {
-      if (table.members[i].row == r) inRow++;
+      if (table.members[i].row == r && table.members[i].width != 0) inRow++;
     }
     if (inRow == 0) return {false, "Rows must be contiguous from 0"};
 
@@ -94,7 +100,7 @@ inline ClusterVerdict validateMemberTable(const ClusterMemberTable& table,
       int span = -1;
       for (int i = 0; i < table.count; i++) {
         const ClusterMemberDef& m = table.members[i];
-        if (m.row != r || m.col != cursor) continue;
+        if (m.row != r || m.col != cursor || m.width == 0) continue;
         if (span != -1 && m.width != span) {
           return {false, "Members overlap"};
         }

--- a/firmware/v2/Master/ClusterLeader.cpp
+++ b/firmware/v2/Master/ClusterLeader.cpp
@@ -1495,7 +1495,11 @@ int clusterLeaderMirrorRows(String* rows, int& selfRowOut,
   LeaderLock lock;
   for (int i = 0; i < table.count; i++) {
     if (clusterMemberIsSelf(table.members[i])) {
-      selfRowOut = table.members[i].row;
+      // #333: a width-0 self member is OFF-GRID — a headless leader (monitor/
+      // backup, no units of its own) renders no row, so leave selfRowOut at
+      // -1. Its `row` is meaningless off-grid and would wrongly anchor the
+      // self health strip under a follower's row.
+      if (table.members[i].width != 0) selfRowOut = table.members[i].row;
       break;
     }
   }

--- a/firmware/v2/Master/ClusterLeader.cpp
+++ b/firmware/v2/Master/ClusterLeader.cpp
@@ -31,6 +31,7 @@
 #include "MqttService.h"  // mqttNotificationActive — self-row re-show gate
 #include "ReflashPlan.h"
 #include "Tasks.h"
+#include "WebEndpoints.h"  // #337: webDisplayContentSnapshot() — leader's mode
 
 #define CLUSTER_KEY_MEMBERS "clMembers"
 
@@ -481,6 +482,11 @@ static std::atomic<bool> rebootHoldSent{false};
 // core-0 idle past the 5 s task watchdog. clusterFanoutNext round-robins so a
 // stuck dead host can't monopolize the fan-out.
 static int collectMemberWork(MemberWorkItem* items) {
+  // #337: capture the leader's mode for the digest BEFORE taking LeaderLock.
+  // webDisplayContentSnapshot() takes WebStateLock, and the documented order is
+  // WebStateLock -> clusterMutex — nesting it the other way deadlocks against
+  // netTask's settings drain (WebStateLock -> clusterLeaderSubmit*).
+  String leaderMode = webDisplayContentSnapshot().deviceMode;
   LeaderLock lock;
   int count = 0;
   uint32_t nowMs = millis();
@@ -583,7 +589,7 @@ static int collectMemberWork(MemberWorkItem* items) {
     String body = clusterBuildDigest(0, leaderDeviceName,
                                      WiFi.localIP().toString(),
                                      clusterTableToString(table), mirror,
-                                     rowCount, st, rebootHoldMs);
+                                     rowCount, st, rebootHoldMs, leaderMode);
     if (body != digestLastBody) {
       digestLastBody = body;
       digestGen++;
@@ -1200,6 +1206,7 @@ static int rebootHoldCount = 0;
 static int rebootHoldCursor = 0;
 
 static void rebootHoldBuildTargets() {
+  String leaderMode = webDisplayContentSnapshot().deviceMode;  // #337: before the lock
   LeaderLock lock;
   rebootHoldCount = 0;
   rebootHoldCursor = 0;
@@ -1214,7 +1221,7 @@ static void rebootHoldBuildTargets() {
   String body =
       clusterBuildDigest(0, leaderDeviceName, WiFi.localIP().toString(),
                          clusterTableToString(table), mirror, rowCount, st,
-                         rebootHoldMs);
+                         rebootHoldMs, leaderMode);
   if (body != digestLastBody) {
     digestLastBody = body;
     digestGen++;

--- a/firmware/v2/Master/DisplayIpc.h
+++ b/firmware/v2/Master/DisplayIpc.h
@@ -70,6 +70,11 @@ struct DisplaySnapshot {
   // displayApplyUnitFacts(), never patched individually.
   uint8_t detectedUnitCount = 0;
   uint8_t faultyUnitCount = 0;
+  // #329 headless mode: latched by displayTask's HeadlessDetector after N
+  // consecutive 0-unit probes — NOT derived by displayApplyUnitFacts (a
+  // single probe's 0 must not flip a real display). Drives /settings'
+  // headlessSuggested nudge.
+  bool headlessUnitless = false;
   UnitFacts units[UNITS_AMOUNT];
   MaintResult lastMaint;
   // Reflash job progress (#205) — published at unit boundaries and settle

--- a/firmware/v2/Master/DisplayIpc.h
+++ b/firmware/v2/Master/DisplayIpc.h
@@ -168,7 +168,14 @@ inline void displayApplyUnitFacts(DisplaySnapshot& snap,
                  u.physLetter != snap.lastFrameLetters[i];
   }
   int width = computeDisplayWidth(states, maxUnits);
-  if (widthOverride >= 1 && widthOverride <= maxUnits) width = widthOverride;
+  if (widthOverride == -1) {
+    // #331 headless: deviceRole=headless-* forces displayWidth 0 — the board
+    // renders nothing and reports no phantom row, overriding both the probe
+    // ceiling fallback and the #289 unit-count override.
+    width = 0;
+  } else if (widthOverride >= 1 && widthOverride <= maxUnits) {
+    width = widthOverride;
+  }
   snap.displayWidth = (uint8_t)width;
   snap.detectedUnitCount = (uint8_t)countRespondingUnits(states, maxUnits);
   snap.faultyUnitCount = (uint8_t)computeFaultyUnitCount(snap.units, maxUnits);

--- a/firmware/v2/Master/HeadlessPolicy.h
+++ b/firmware/v2/Master/HeadlessPolicy.h
@@ -1,0 +1,72 @@
+#pragma once
+// HeadlessPolicy.h — pure no-units detection debounce + the deviceRole wire
+// vocabulary (#329). A physically unit-less S3 master should stop enrolling
+// itself as an empty phantom display row and take a genuinely useful role
+// instead; this header owns the single-sourced role strings, their validator,
+// and the debounce that decides WHEN a board is unit-less enough to suggest a
+// headless role. Every symbol is pure (String only) so it is natively tested
+// (test/test_headless_policy) and shared by Settings.h and the /settings
+// surface. The role BEHAVIOURS live elsewhere (later slices).
+
+#include <Arduino.h>
+
+// deviceRole wire values — mirror deviceMode's frozen /settings vocabulary.
+// "display" is the default: a unit-driving wall row. The three headless roles
+// are non-rendering and occupy no wall columns (width 0).
+#define DEVICE_ROLE_DISPLAY          "display"
+#define DEVICE_ROLE_HEADLESS_BACKUP  "headless-backup"   // warm-standby master
+#define DEVICE_ROLE_HEADLESS_MONITOR "headless-monitor"  // cluster dashboard
+#define DEVICE_ROLE_HEADLESS_SPARE   "headless-spare"    // idle clean spare
+
+// deviceRole POST validator — exact match against the four wire values, like
+// isValidDeviceModeValue. Rejects case variants, empty and unknowns so a raw
+// POST can never persist garbage.
+static inline bool isValidDeviceRoleValue(const String& v) {
+  return v == DEVICE_ROLE_DISPLAY ||
+         v == DEVICE_ROLE_HEADLESS_BACKUP ||
+         v == DEVICE_ROLE_HEADLESS_MONITOR ||
+         v == DEVICE_ROLE_HEADLESS_SPARE;
+}
+
+// True for any of the three non-rendering roles (i.e. not "display").
+static inline bool isHeadlessRole(const String& role) {
+  return role == DEVICE_ROLE_HEADLESS_BACKUP ||
+         role == DEVICE_ROLE_HEADLESS_MONITOR ||
+         role == DEVICE_ROLE_HEADLESS_SPARE;
+}
+
+// Consecutive 0-unit probes before a board is flagged unit-less. The display
+// probe/health poll runs on a multi-second cadence, so a few in a row is a
+// real "nothing on the bus" verdict — long enough that a transient bus glitch
+// on a genuine display never trips it.
+static constexpr int HEADLESS_ZERO_PROBE_THRESHOLD = 3;
+
+// Debounce state — a plain counter; the owner (displayTask) keeps one and
+// feeds every fresh probe through headlessObserveProbe.
+struct HeadlessDetector {
+  int zeroStreak = 0;
+};
+
+// Feed one probe's detected-unit count. Returns true once the board has seen
+// `threshold` CONSECUTIVE zero-unit probes (unit-less). Any probe that finds a
+// unit resets the streak, so a real display whose units blink out briefly is
+// never flagged. The counter saturates at the threshold — no unbounded growth.
+static inline bool headlessObserveProbe(
+    HeadlessDetector& d, int detectedUnitCount,
+    int threshold = HEADLESS_ZERO_PROBE_THRESHOLD) {
+  if (detectedUnitCount > 0) {
+    d.zeroStreak = 0;
+    return false;
+  }
+  if (d.zeroStreak < threshold) d.zeroStreak++;
+  return d.zeroStreak >= threshold;
+}
+
+// Whether the UI should surface the "you look unit-less — pick a headless
+// role" suggestion: detection has latched AND the user is still on the default
+// display role (a board already in a headless role needs no nudge). Detection
+// only ever SUGGESTS — every role change is user-confirmed (#329 safety).
+static inline bool headlessShouldSuggest(bool unitlessDetected,
+                                         const String& role) {
+  return unitlessDetected && role == DEVICE_ROLE_DISPLAY;
+}

--- a/firmware/v2/Master/PendingSettingsPost.h
+++ b/firmware/v2/Master/PendingSettingsPost.h
@@ -29,6 +29,7 @@
 #define PARAM_ALIGNMENT       "alignment"
 #define PARAM_FLAP_SPEED      "flapSpeed"
 #define PARAM_DEVICEMODE      "deviceMode"
+#define PARAM_DEVICE_ROLE     "deviceRole"
 #define PARAM_INPUT_TEXT      "inputText"
 #define PARAM_TRANSIENT_TEXT  "transientText"
 #define PARAM_TRANSIENT_DWELL "transientDwell"
@@ -46,6 +47,7 @@ struct PendingSettingsPost {
   String alignment;     bool alignmentProvided = false;
   String flapSpeed;     bool flapSpeedProvided = false;
   String deviceMode;    bool deviceModeProvided = false;
+  String deviceRole;    bool deviceRoleProvided = false;
   String inputText;     bool inputTextProvided = false;
   String transientText; bool transientTextProvided = false;
   long transientDwell = 0;
@@ -89,6 +91,13 @@ inline SettingsParamResult stageSettingsParam(PendingSettingsPost& post,
     if (!isValidDeviceModeValue(rawValue)) return SettingsParamResult::Invalid;
     post.deviceMode = rawValue;
     post.deviceModeProvided = true;
+    return SettingsParamResult::Accepted;
+  }
+
+  if (name == PARAM_DEVICE_ROLE) {
+    if (!isValidDeviceRoleValue(rawValue)) return SettingsParamResult::Invalid;
+    post.deviceRole = rawValue;
+    post.deviceRoleProvided = true;
     return SettingsParamResult::Accepted;
   }
 
@@ -209,6 +218,7 @@ inline void mergeSettingsPost(PendingSettingsPost& shared,
   if (accepted.alignmentProvided)  { shared.alignment  = accepted.alignment;  shared.alignmentProvided  = true; }
   if (accepted.flapSpeedProvided)  { shared.flapSpeed  = accepted.flapSpeed;  shared.flapSpeedProvided  = true; }
   if (accepted.deviceModeProvided) { shared.deviceMode = accepted.deviceMode; shared.deviceModeProvided = true; }
+  if (accepted.deviceRoleProvided) { shared.deviceRole = accepted.deviceRole; shared.deviceRoleProvided = true; }
   if (accepted.inputTextProvided)  { shared.inputText  = accepted.inputText;  shared.inputTextProvided  = true; }
   if (accepted.transientTextProvided) {
     shared.transientText = accepted.transientText;
@@ -253,6 +263,11 @@ inline void applySettingsPost(PendingSettingsPost& post,
   if (post.deviceModeProvided && settings.deviceMode != post.deviceMode) {
     settings.deviceMode = post.deviceMode;
     saveDeviceMode(store, settings.deviceMode);
+  }
+
+  if (post.deviceRoleProvided && settings.deviceRole != post.deviceRole) {
+    settings.deviceRole = post.deviceRole;
+    saveDeviceRole(store, settings.deviceRole);
   }
 
   if (post.timezoneProvided && settings.timezonePosix != post.timezone) {

--- a/firmware/v2/Master/Settings.h
+++ b/firmware/v2/Master/Settings.h
@@ -17,6 +17,7 @@
 #include <Arduino.h>
 
 #include "DeviceIdentity.h"
+#include "HeadlessPolicy.h"
 #include "SettingsLimits.h"
 #include "SettingsStore.h"
 #include "SettingsValidation.h"
@@ -25,6 +26,7 @@
 #define SETTINGS_DEFAULT_ALIGNMENT   "left"
 #define SETTINGS_DEFAULT_FLAP_SPEED  80
 #define SETTINGS_DEFAULT_DEVICE_MODE "text"
+#define SETTINGS_DEFAULT_DEVICE_ROLE DEVICE_ROLE_DISPLAY
 #define SETTINGS_DEFAULT_TIMEZONE    "CET-1CEST,M3.5.0,M10.5.0/3"
 #define SETTINGS_DEFAULT_MQTT_PORT   1883
 
@@ -32,6 +34,8 @@ struct MasterSettings {
   String alignment;
   int flapSpeed;
   String deviceMode;
+  String deviceRole;       // #329 headless mode: display|headless-{backup,
+                           // monitor,spare}. "display" = a unit-driving row.
   String timezonePosix;
   String deviceName;       // "" = chip-id default via resolveDeviceName()
   String wifiSsid;         // "" = unprovisioned (boot lands in the portal)
@@ -51,6 +55,7 @@ struct MasterSettings {
 #define SETTINGS_KEY_ALIGNMENT    "alignment"
 #define SETTINGS_KEY_FLAP_SPEED   "flapSpeed"
 #define SETTINGS_KEY_DEVICE_MODE  "deviceMode"
+#define SETTINGS_KEY_DEVICE_ROLE  "deviceRole"
 #define SETTINGS_KEY_TIMEZONE     "tzPosix"
 #define SETTINGS_KEY_DEVICE_NAME  "deviceName"
 #define SETTINGS_KEY_WIFI_SSID    "wifiSsid"
@@ -89,6 +94,9 @@ inline MasterSettings loadSettings(SettingsStore& store) {
 
   s.deviceMode = store.getString(SETTINGS_KEY_DEVICE_MODE, SETTINGS_DEFAULT_DEVICE_MODE);
   if (!isValidDeviceModeValue(s.deviceMode)) s.deviceMode = SETTINGS_DEFAULT_DEVICE_MODE;
+
+  s.deviceRole = store.getString(SETTINGS_KEY_DEVICE_ROLE, SETTINGS_DEFAULT_DEVICE_ROLE);
+  if (!isValidDeviceRoleValue(s.deviceRole)) s.deviceRole = SETTINGS_DEFAULT_DEVICE_ROLE;
 
   s.timezonePosix = store.getString(SETTINGS_KEY_TIMEZONE, SETTINGS_DEFAULT_TIMEZONE);
   if (!isValidTimezoneValue(s.timezonePosix, LEN_TIMEZONE)) {
@@ -149,6 +157,10 @@ inline void saveFlapSpeed(SettingsStore& store, int v) {
 
 inline void saveDeviceMode(SettingsStore& store, const String& v) {
   store.putString(SETTINGS_KEY_DEVICE_MODE, v);
+}
+
+inline void saveDeviceRole(SettingsStore& store, const String& v) {
+  store.putString(SETTINGS_KEY_DEVICE_ROLE, v);
 }
 
 inline void saveTimezone(SettingsStore& store, const String& v) {

--- a/firmware/v2/Master/SettingsJson.h
+++ b/firmware/v2/Master/SettingsJson.h
@@ -63,6 +63,15 @@ struct SettingsJsonFields {
   // effective width already carried by unitCount.
   int unitCountOverride = 0;
 
+  // Per-board vitals (#335) so cluster members surface heap/rssi/uptime in
+  // the System-tab panel — same keys/units as the ESP-01 follower's #297
+  // block. `plat` is this board's platform tag (esp32s3), the S3 counterpart
+  // to the ESP-01's "esp01"; the member UI keys the model label off it.
+  uint32_t heapBytes = 0;
+  int rssiDbm = 0;
+  uint32_t upSeconds = 0;
+  String plat = "esp32s3";  // mirrors ClusterLeaderPolicy.h CLUSTER_LEADER_PLAT
+
   // Cluster membership (#272): drives the follower banner + card gating.
   // "standalone" = not clustered (the cluster-disabled default).
   String clusterState = "standalone";
@@ -168,6 +177,12 @@ inline String buildSettingsJson(const SettingsJsonFields& f) {
   out += ",\"clusterLeaderHost\":"; appendJsonString(out, f.clusterLeaderHost);
   out += ",\"clusterRow\":";        out += f.clusterRow;
   out += ",\"clusterLeading\":";    appendJsonBool(out, f.clusterLeading);
+  // #335 per-board vitals — same keys/units as the ESP-01 follower so the
+  // cluster member panel renders S3 rows identically.
+  out += ",\"heap\":";              out += String(f.heapBytes);
+  out += ",\"rssi\":";              out += f.rssiDbm;
+  out += ",\"up\":";                out += String(f.upSeconds);
+  out += ",\"plat\":";              appendJsonString(out, f.plat);
 
   out += '}';
   return out;

--- a/firmware/v2/Master/SettingsJson.h
+++ b/firmware/v2/Master/SettingsJson.h
@@ -13,6 +13,8 @@
 
 #include <Arduino.h>
 
+#include "HeadlessPolicy.h"
+
 struct SettingsJsonFields {
   // Bus/probe results. unitsAmount is the per-unit array length (the
   // UNITS_AMOUNT ceiling); null array pointers emit per-slot defaults
@@ -27,6 +29,11 @@ struct SettingsJsonFields {
   String alignment;
   String flapSpeed;  // string-typed on the wire, v1 parity
   String deviceMode;
+  // #329 headless mode: the stored role + the auto-detect nudge. "display"
+  // (default) keeps old UIs unaffected; headlessSuggested drives the "you
+  // look unit-less — pick a role" banner (detection only ever suggests).
+  String deviceRole = DEVICE_ROLE_DISPLAY;
+  bool headlessSuggested = false;
   String timezonePosix;
   String deviceName;           // raw stored value ("" = unset)
   String effectiveDeviceName;  // what the device actually uses right now
@@ -130,6 +137,8 @@ inline String buildSettingsJson(const SettingsJsonFields& f) {
   out += ",\"alignment\":";           appendJsonString(out, f.alignment);
   out += ",\"flapSpeed\":";           appendJsonString(out, f.flapSpeed);
   out += ",\"deviceMode\":";          appendJsonString(out, f.deviceMode);
+  out += ",\"deviceRole\":";          appendJsonString(out, f.deviceRole);
+  out += ",\"headlessSuggested\":";   appendJsonBool(out, f.headlessSuggested);
   out += ",\"timezonePosix\":";       appendJsonString(out, f.timezonePosix);
   out += ",\"deviceName\":";          appendJsonString(out, f.deviceName);
   out += ",\"effectiveDeviceName\":"; appendJsonString(out, f.effectiveDeviceName);

--- a/firmware/v2/Master/Tasks.cpp
+++ b/firmware/v2/Master/Tasks.cpp
@@ -22,6 +22,7 @@ void tasksSetUnitCountOverride(int count) {
 #include "ClusterFollower.h"
 #include "ClusterLeader.h"
 #include "FlapFrame.h"
+#include "HeadlessPolicy.h"
 #include "HeartbeatPolicy.h"
 #include "HelpersSerialHandling.h"
 #include "MqttService.h"
@@ -171,6 +172,19 @@ static void settleBeforeProbe() {
   if (remaining > 0) delay((uint32_t)remaining);
 }
 
+// No-units detection (#329). displayTask owns this exclusively (single core-1
+// task), so a plain static needs no lock. Fed only at the STEADY observation
+// points — boot probe, explicit Probe, idle heartbeat tick — not the transient
+// maintenance/reflash reprobes, so the streak tracks real bus cadence. Latches
+// headlessUnitless after HEADLESS_ZERO_PROBE_THRESHOLD consecutive 0-unit
+// reads; a single responding unit resets it (never flips a real display).
+static HeadlessDetector headlessDetector;
+
+static void headlessTrack(DisplaySnapshot& local) {
+  local.headlessUnitless =
+      headlessObserveProbe(headlessDetector, local.detectedUnitCount);
+}
+
 // --- heartbeat freshness + batched boot-home (#309/#310) ---------------------
 
 // A full health poll + a freshness stamp for every slot (#310, HeartbeatPolicy).
@@ -236,6 +250,7 @@ static void heartbeatTick(DisplaySnapshot& local, UnitFacts* busFacts,
   heartbeatApply(busFacts[i], ok, millis(), HEARTBEAT_MISS_THRESHOLD);
   displayApplyUnitFacts(local, busFacts, UNITS_AMOUNT,
                         unitWidthOverride.load(std::memory_order_relaxed));
+  headlessTrack(local);  // #329: idle-tick observation feeds the debounce
   snapshotPublish(local);
 }
 
@@ -425,6 +440,7 @@ static void displayTaskMain(void*) {
   pollHealthWithFreshness(busFacts);
   displayApplyUnitFacts(local, busFacts, UNITS_AMOUNT,
                         unitWidthOverride.load(std::memory_order_relaxed));
+  headlessTrack(local);  // #329: first (boot) observation
   snapshotPublish(local);
   if (local.detectedUnitCount == 0) {
     SerialPrintf("display: no units responding — assuming full width %d\n",
@@ -494,6 +510,7 @@ static void displayTaskMain(void*) {
           pollHealthWithFreshness(busFacts);
           displayApplyUnitFacts(local, busFacts, UNITS_AMOUNT,
                         unitWidthOverride.load(std::memory_order_relaxed));
+          headlessTrack(local);  // #329: explicit-probe observation
           break;
         // --- calibration + provisioning (#204). Every op grades a
         // MaintResult; the web layer serves it via /unit/op-result.

--- a/firmware/v2/Master/Tasks.cpp
+++ b/firmware/v2/Master/Tasks.cpp
@@ -13,8 +13,27 @@
 // reads it at every fold; 0 = auto (probe-derived width).
 static std::atomic<int> unitWidthOverride{0};
 
+// #331 headless mode: true while deviceRole is a headless role. It forces
+// displayWidth 0 (the board renders nothing, no phantom row), overriding the
+// probe ceiling AND the #289 override — passed to displayApplyUnitFacts as
+// the -1 sentinel via effectiveWidthOverride(). Seeded by tasksInit(),
+// pushed live by the settings drain (netTask).
+static std::atomic<bool> deviceRoleHeadless{false};
+
 void tasksSetUnitCountOverride(int count) {
   unitWidthOverride.store(count, std::memory_order_relaxed);
+}
+
+void tasksSetDeviceRole(const String& role) {
+  deviceRoleHeadless.store(isHeadlessRole(role), std::memory_order_relaxed);
+}
+
+// The width-override value handed to displayApplyUnitFacts: -1 (force width 0)
+// while headless, else the #289 unit-count override (0 = auto).
+static int effectiveWidthOverride() {
+  return deviceRoleHeadless.load(std::memory_order_relaxed)
+             ? -1
+             : unitWidthOverride.load(std::memory_order_relaxed);
 }
 
 #include "BootHomePlan.h"
@@ -230,7 +249,7 @@ static void runBootHomeSequence(DisplaySnapshot& local, UnitFacts* busFacts) {
   // Re-poll so the published snapshot reflects the now-homed state.
   pollHealthWithFreshness(busFacts);
   displayApplyUnitFacts(local, busFacts, UNITS_AMOUNT,
-                        unitWidthOverride.load(std::memory_order_relaxed));
+                        effectiveWidthOverride());
   snapshotPublish(local);
 }
 
@@ -249,7 +268,7 @@ static void heartbeatTick(DisplaySnapshot& local, UnitFacts* busFacts,
   bool ok = unitBusPollHealthOne(busFacts, i);
   heartbeatApply(busFacts[i], ok, millis(), HEARTBEAT_MISS_THRESHOLD);
   displayApplyUnitFacts(local, busFacts, UNITS_AMOUNT,
-                        unitWidthOverride.load(std::memory_order_relaxed));
+                        effectiveWidthOverride());
   headlessTrack(local);  // #329: idle-tick observation feeds the debounce
   snapshotPublish(local);
 }
@@ -342,7 +361,7 @@ static void runReflashJob(DisplaySnapshot& local, UnitFacts* busFacts,
   // actually sits in twiboot, then plan the flash list from live truth.
   unitBusProbe(busFacts, UNITS_AMOUNT);
   displayApplyUnitFacts(local, busFacts, UNITS_AMOUNT,
-                        unitWidthOverride.load(std::memory_order_relaxed));
+                        effectiveWidthOverride());
   uint8_t targets[UNITS_AMOUNT];
   int total = reflashCollectFlashTargets(local.units, UNITS_AMOUNT,
                                          SFP_I2C_ADDRESS_BASE, targets);
@@ -411,7 +430,7 @@ static void runReflashJob(DisplaySnapshot& local, UnitFacts* busFacts,
   unitBusProbe(busFacts, UNITS_AMOUNT);
   pollHealthWithFreshness(busFacts);
   displayApplyUnitFacts(local, busFacts, UNITS_AMOUNT,
-                        unitWidthOverride.load(std::memory_order_relaxed));
+                        effectiveWidthOverride());
   // Staggered boot-home of the just-flashed units (#309): a reflashed unit
   // reboots UNHOMED, so without this the caller's re-show (or the next cluster
   // render) would home every flashed unit at once — the #305 inrush #309
@@ -439,12 +458,16 @@ static void displayTaskMain(void*) {
   unitBusProbe(busFacts, UNITS_AMOUNT);
   pollHealthWithFreshness(busFacts);
   displayApplyUnitFacts(local, busFacts, UNITS_AMOUNT,
-                        unitWidthOverride.load(std::memory_order_relaxed));
+                        effectiveWidthOverride());
   headlessTrack(local);  // #329: first (boot) observation
   snapshotPublish(local);
   if (local.detectedUnitCount == 0) {
-    SerialPrintf("display: no units responding — assuming full width %d\n",
-                 local.displayWidth);
+    if (local.displayWidth == 0) {
+      SerialPrintln("display: no units — headless role, display disabled");  // #331
+    } else {
+      SerialPrintf("display: no units responding — assuming full width %d\n",
+                   local.displayWidth);
+    }
   } else {
     SerialPrintf("display: probe done, width %d\n", local.displayWidth);
   }
@@ -509,7 +532,7 @@ static void displayTaskMain(void*) {
           unitBusProbe(busFacts, UNITS_AMOUNT);
           pollHealthWithFreshness(busFacts);
           displayApplyUnitFacts(local, busFacts, UNITS_AMOUNT,
-                        unitWidthOverride.load(std::memory_order_relaxed));
+                        effectiveWidthOverride());
           headlessTrack(local);  // #329: explicit-probe observation
           break;
         // --- calibration + provisioning (#204). Every op grades a
@@ -696,7 +719,7 @@ static void displayTaskMain(void*) {
           unitBusProbe(busFacts, UNITS_AMOUNT);
           pollHealthWithFreshness(busFacts);
           displayApplyUnitFacts(local, busFacts, UNITS_AMOUNT,
-                        unitWidthOverride.load(std::memory_order_relaxed));
+                        effectiveWidthOverride());
           MaintReason reason = MaintReason::None;
           MaintOutcome outcome = classifySetAddressOutcome(
               local.units, UNITS_AMOUNT, cmd.value, reason);
@@ -716,7 +739,7 @@ static void displayTaskMain(void*) {
           unitBusProbe(busFacts, UNITS_AMOUNT);
           pollHealthWithFreshness(busFacts);
           displayApplyUnitFacts(local, busFacts, UNITS_AMOUNT,
-                        unitWidthOverride.load(std::memory_order_relaxed));
+                        effectiveWidthOverride());
           MaintReason reason = MaintReason::None;
           MaintOutcome outcome = classifyClearAddressOutcome(
               countBefore, local.detectedUnitCount, reason);
@@ -966,6 +989,8 @@ static void clusterTaskMain(void*) {
 void tasksInit(MasterSettings& settings, SettingsStore& store) {
   unitWidthOverride.store(settings.unitCountOverride,
                           std::memory_order_relaxed);
+  deviceRoleHeadless.store(isHeadlessRole(settings.deviceRole),
+                           std::memory_order_relaxed);  // #331
   snapshotMutex = xSemaphoreCreateMutex();
   if (snapshotMutex == nullptr) {
     // Boot-time OOM: taking a null handle is UB, so fail loudly instead —

--- a/firmware/v2/Master/Tasks.h
+++ b/firmware/v2/Master/Tasks.h
@@ -51,6 +51,11 @@ void tasksInit(MasterSettings& settings, SettingsStore& store);
 // queues a Probe right after calling this.
 void tasksSetUnitCountOverride(int count);
 
+// #331 headless: push a changed deviceRole to displayTask. A headless role
+// forces displayWidth 0 (no display, no phantom row) at the next fold — the
+// settings drain queues a Probe right after calling this.
+void tasksSetDeviceRole(const String& role);
+
 // Non-blocking enqueue into the display task; false = queue full (callers
 // report, never wait — network context must not block on the display).
 bool displayEnqueue(const DisplayCommand& cmd);

--- a/firmware/v2/Master/WebEndpoints.cpp
+++ b/firmware/v2/Master/WebEndpoints.cpp
@@ -338,6 +338,12 @@ static String buildCurrentSettingsJson() {
   f.detectedUnitAddresses = addrs;
   f.detectedUnitVersionStatus = fwStatus;
   f.detectedUnitVersions = versions;
+  // #335 per-board vitals — runtime, no settings lock needed. Same source as
+  // the ESP-01 follower (heap bytes / RSSI dBm / uptime seconds); plat keeps
+  // its "esp32s3" default. Lets S3 cluster members show vitals like the ESP-01.
+  f.heapBytes = ESP.getFreeHeap();
+  f.rssiDbm = WiFi.RSSI();
+  f.upSeconds = millis() / 1000;
   {
     WebStateLock lock;
     f.alignment = liveSettings->alignment;

--- a/firmware/v2/Master/WebEndpoints.cpp
+++ b/firmware/v2/Master/WebEndpoints.cpp
@@ -343,6 +343,11 @@ static String buildCurrentSettingsJson() {
     f.alignment = liveSettings->alignment;
     f.flapSpeed = String(liveSettings->flapSpeed);
     f.deviceMode = liveSettings->deviceMode;
+    f.deviceRole = liveSettings->deviceRole;
+    // #329: nudge only while still on the default display role — detection
+    // suggests, never self-demotes.
+    f.headlessSuggested =
+        headlessShouldSuggest(snap.headlessUnitless, liveSettings->deviceRole);
     f.timezonePosix = liveSettings->timezonePosix;
     f.unitCountOverride = liveSettings->unitCountOverride;
     f.deviceName = liveSettings->deviceName;

--- a/firmware/v2/Master/WebEndpoints.cpp
+++ b/firmware/v2/Master/WebEndpoints.cpp
@@ -2058,13 +2058,19 @@ void webEndpointsLoop(MasterSettings& settings, SettingsStore& store) {
       // same POST as a message must apply to that message (v1 ordering).
       String timezoneBefore = settings.timezonePosix;
       int unitCountBefore = settings.unitCountOverride;
+      String deviceRoleBefore = settings.deviceRole;
       applySettingsPost(pendingPost, settings, store);
       timezoneChanged = settings.timezonePosix != timezoneBefore;
 
-      // #289 dummy mode: push the changed override to displayTask and queue
-      // a Probe so the width refolds now instead of at the next bus op.
+      // #289 dummy mode / #331 headless: push a changed override or deviceRole
+      // to displayTask and queue a Probe so the width refolds now instead of
+      // at the next bus op (a headless role forces displayWidth 0).
       if (settings.unitCountOverride != unitCountBefore) {
         tasksSetUnitCountOverride(settings.unitCountOverride);
+        displayEnqueue(makeProbeCommand());
+      }
+      if (settings.deviceRole != deviceRoleBefore) {
+        tasksSetDeviceRole(settings.deviceRole);
         displayEnqueue(makeProbeCommand());
       }
 

--- a/firmware/v2/Master/data/index.html
+++ b/firmware/v2/Master/data/index.html
@@ -278,6 +278,22 @@
 				</div>
 
 				<div class="card">
+					<h2>Device role <span id="labelDeviceRole" class="pill off">display</span></h2>
+					<p class="note">What this board is for. A master with no flap units on its I2C bus can take a non-display role instead of showing a blank wall row. Detection only <em>suggests</em> — you confirm the role here; it never switches on its own.</p>
+					<div id="deviceRoleSuggestion" class="banner hidden">This master detects no units — it looks unit-less. Pick a headless role below, or leave it as <b>Display</b>.</div>
+					<div class="row" style="margin-top:12px">
+						<div class="seg" id="segDeviceRole">
+							<button type="button" data-value="display">Display</button>
+							<button type="button" data-value="headless-backup">Backup master</button>
+							<button type="button" data-value="headless-monitor">Monitor</button>
+							<button type="button" data-value="headless-spare">Spare</button>
+						</div>
+					</div>
+					<p class="note">Headless role behavior (warm-standby takeover, cluster dashboard, idle spare) ships in a follow-up — for now the board still runs as a display whichever role is set; your choice is saved.</p>
+					<p id="deviceRoleStatus" class="status hidden"></p>
+				</div>
+
+				<div class="card">
 					<h2>Master firmware <span id="labelVersion" class="pill off">—</span></h2>
 					<p class="note">Upload a compiled <code>firmware.bin</code> to flash the ESP itself. It reboots into the new firmware on success.</p>
 					<form id="masterFirmwareForm">

--- a/firmware/v2/Master/data/script.js
+++ b/firmware/v2/Master/data/script.js
@@ -425,6 +425,18 @@ function applySettings(s) {
 		overridePill.className = "pill " + (overrideValue > 0 ? "ok" : "off");
 	}
 
+	//#330 headless mode: reflect the stored deviceRole and the unit-less
+	//suggestion. Detection only nudges (banner) — the user picks the role.
+	var role = s.deviceRole || "display";
+	setSegValue("segDeviceRole", role);
+	var rolePill = document.getElementById("labelDeviceRole");
+	if (rolePill) {
+		rolePill.textContent = role === "display" ? "display" : role.replace("headless-", "");
+		rolePill.className = "pill " + (role === "display" ? "off" : "ok");
+	}
+	var roleBanner = document.getElementById("deviceRoleSuggestion");
+	if (roleBanner) roleBanner.classList.toggle("hidden", !s.headlessSuggested);
+
 	document.getElementById("boardName").textContent = (s.effectiveDeviceName || "split-flap").toUpperCase();
 	refreshLiveStatus();
 	document.getElementById("labelLastMessageReceived").textContent = s.lastTimeReceivedMessageDateTime || "—";
@@ -916,6 +928,16 @@ function initSegControls() {
 			currentAlignment = b.dataset.value;
 			postSettingsFields({ alignment: b.dataset.value }, function(ok) {
 				showStatus("displayStatus", ok ? "✔ Alignment saved." : "✘ Alignment save failed.", ok ? "success" : "error", 4000);
+			});
+		});
+	});
+	//#330 headless mode: deviceRole selector — posts only its own field, the
+	//poll loop reflects the device's answer back like the other segments.
+	document.querySelectorAll("#segDeviceRole button").forEach(function(b) {
+		b.addEventListener("click", function() {
+			setSegValue("segDeviceRole", b.dataset.value);
+			postSettingsFields({ deviceRole: b.dataset.value }, function(ok) {
+				showStatus("deviceRoleStatus", ok ? "✔ Role saved." : "✘ Role save failed.", ok ? "success" : "error", 4000);
 			});
 		});
 	});

--- a/firmware/v2/Master/data/script.js
+++ b/firmware/v2/Master/data/script.js
@@ -2826,8 +2826,8 @@ function refreshSysClusterVitals() {
 			.then(function(r) { if (!r.ok) throw new Error(); return r.json(); })
 			.then(function(s) {
 				if (s.version) revC.textContent = s.version;
-				//Only the ESP-01 dumb row carries these (#297); an S3 member's
-				///settings has none, so its vitals stay dashed.
+				//Both S3 (#335) and ESP-01 (#297) rows carry these now; a member
+				//on older firmware omits them and its vitals stay dashed.
 				heapC.textContent = s.heap !== undefined ? Math.round(s.heap / 1024) + " KB" : "—";
 				rssiC.textContent = s.rssi !== undefined ? s.rssi + " dBm" : "—";
 				upC.textContent = s.up !== undefined ? formatUptime(s.up) : "—";

--- a/firmware/v2/Master/data/script.js
+++ b/firmware/v2/Master/data/script.js
@@ -2688,7 +2688,9 @@ function renderClusterMembers() {
 		tr.appendChild(hostTd);
 
 		tr.appendChild(numberCell("col", 0, 254));
-		tr.appendChild(numberCell("width", 1, 255));
+		//#333 warm-standby: width 0 = an off-grid backup member (no columns,
+		//non-rendering, promote-eligible) — the leader accepts it.
+		tr.appendChild(numberCell("width", 0, 255));
 
 		var stateTd = document.createElement("td");
 		var pill = document.createElement("span");

--- a/firmware/v2/Master/data/script.js
+++ b/firmware/v2/Master/data/script.js
@@ -2608,11 +2608,14 @@ function updateClusterFromStatus(st) {
 		var label = clusterStateLabel(saved[i]);
 		pill.className = "pill " + label.kind + " cl-state";
 		pill.textContent = label.text;
-		//plat tag (#297) + wire-auth chip (#317): only for non-self members
-		//(the leader's own row is not a wire link). hmac = leader signs to it.
+		//#334: rev + platform for EVERY member incl. (this board). plat is
+		//sent only by ESP-01 (#297) — absent means the S3 fleet, so fall back
+		//to esp32s3. The #317 wire-auth chip stays non-self only (the leader's
+		//own row is not a wire link). hmac = leader signs to it.
 		rev.textContent = "";
+		rev.appendChild(document.createTextNode(
+			(saved[i].rev || "—") + " · " + (saved[i].plat || "esp32s3") + "  "));
 		if (!saved[i].self) {
-			rev.appendChild(document.createTextNode((saved[i].rev || "—") + (saved[i].plat ? " · " + saved[i].plat : "") + "  "));
 			var authChip = document.createElement("span");
 			authChip.className = "pill " + (saved[i].hmac ? "ok" : "off");
 			authChip.style.fontSize = "10px";

--- a/firmware/v2/Master/test/test_cluster_digest/test_main.cpp
+++ b/firmware/v2/Master/test/test_cluster_digest/test_main.cpp
@@ -430,9 +430,22 @@ static void test_successor_list_orders_multiple_s3_by_index() {
   st.memberCount = 4;
   st.members[2].host = "192.168.1.50";
   st.members[2].plat = "esp32s3";
+  st.members[2].width = 16;  // rendering row — width now carries meaning (#333)
   st.members[3].host = "192.168.1.51";
   st.members[3].plat = "esp01";  // excluded
   TEST_ASSERT_EQUAL_STRING("1,2", clusterSuccessorList(st).c_str());
+}
+
+// #333: a width-0 warm-standby backup outranks the rendering rows — it has
+// no row of its own to lose, so it is the preferred successor (rank 0).
+static void test_successor_list_prefers_zero_width_backup() {
+  ClusterLeaderStatus st = makeStatus();
+  st.memberCount = 3;
+  st.members[2].host = "192.168.1.50";
+  st.members[2].plat = "";   // same platform (S3)
+  st.members[2].width = 0;   // warm-standby backup
+  // Backup (index 2) leads the rendering follower (index 1).
+  TEST_ASSERT_EQUAL_STRING("2,1", clusterSuccessorList(st).c_str());
 }
 
 static void test_digest_carries_succ_field() {
@@ -456,6 +469,7 @@ int main(int, char**) {
   RUN_TEST(test_successor_list_includes_s3_followers);
   RUN_TEST(test_successor_list_excludes_esp01);
   RUN_TEST(test_successor_list_orders_multiple_s3_by_index);
+  RUN_TEST(test_successor_list_prefers_zero_width_backup);
   RUN_TEST(test_digest_carries_succ_field);
   RUN_TEST(test_digest_carries_hold_when_rebooting);
   RUN_TEST(test_fault_mask_all_healthy_is_zeroes);

--- a/firmware/v2/Master/test/test_cluster_digest/test_main.cpp
+++ b/firmware/v2/Master/test/test_cluster_digest/test_main.cpp
@@ -456,6 +456,23 @@ static void test_digest_carries_succ_field() {
   TEST_ASSERT_TRUE(d.indexOf("\"hold\":0") >= 0);  // #321: 0 unless rebooting
 }
 
+// #337: the leader's active deviceMode rides the digest so a promoted
+// successor resumes the cluster mode instead of its own NVS default.
+static void test_digest_carries_mode_field() {
+  ClusterLeaderStatus st = makeStatus();
+  String rows[1] = {"HELLO"};
+  String d = clusterBuildDigest(3, "wall", "192.168.1.2", "a|0|0|16", rows, 1, st,
+                                0, "clock");
+  TEST_ASSERT_TRUE(d.indexOf("\"mode\":\"clock\"") >= 0);
+}
+
+static void test_digest_mode_defaults_empty() {
+  ClusterLeaderStatus st = makeStatus();
+  String rows[1] = {"HELLO"};
+  String d = clusterBuildDigest(3, "wall", "192.168.1.2", "a|0|0|16", rows, 1, st);
+  TEST_ASSERT_TRUE(d.indexOf("\"mode\":\"\"") >= 0);
+}
+
 static void test_digest_carries_hold_when_rebooting() {
   ClusterLeaderStatus st = makeStatus();
   String rows[1] = {"HELLO"};
@@ -471,6 +488,8 @@ int main(int, char**) {
   RUN_TEST(test_successor_list_orders_multiple_s3_by_index);
   RUN_TEST(test_successor_list_prefers_zero_width_backup);
   RUN_TEST(test_digest_carries_succ_field);
+  RUN_TEST(test_digest_carries_mode_field);
+  RUN_TEST(test_digest_mode_defaults_empty);
   RUN_TEST(test_digest_carries_hold_when_rebooting);
   RUN_TEST(test_fault_mask_all_healthy_is_zeroes);
   RUN_TEST(test_fault_mask_bit_is_unit_index);

--- a/firmware/v2/Master/test/test_cluster_layout/test_main.cpp
+++ b/firmware/v2/Master/test/test_cluster_layout/test_main.cpp
@@ -91,11 +91,62 @@ static void test_count_over_max_rejected() {
   TEST_ASSERT_FALSE(validateMemberTable(t, grid).ok);
 }
 
-static void test_zero_width_member_rejected() {
+// #333 warm-standby backup: a width-0 member is OFF-GRID — it holds
+// membership (pings, digest, promote rank) but occupies no columns, so it is
+// accepted and never appears in the derived grid (no row, no width).
+static void test_zero_width_member_off_grid() {
+  ClusterGrid grid;
+  ClusterMemberTable t = makeRows(2, 16);  // rows 0,1 each 16 wide
+  t.count = 3;
+  snprintf(t.members[2].host, sizeof(t.members[2].host), "backup.local");
+  t.members[2].row = 0;
+  t.members[2].col = 0;  // coincident with the real row-0 member — no overlap
+  t.members[2].width = 0;
+  ClusterVerdict v = validateMemberTable(t, grid);
+  TEST_ASSERT_TRUE(v.ok);
+  TEST_ASSERT_EQUAL(2, grid.rows);          // backup added no row
+  TEST_ASSERT_EQUAL(16, grid.rowWidth[0]);  // nor widened its row
+  TEST_ASSERT_EQUAL(16, grid.rowWidth[1]);
+}
+
+// #333: a table where EVERY member is off-grid (width 0) renders nothing —
+// reject it rather than "enabling" an empty wall.
+static void test_all_off_grid_table_rejected() {
+  ClusterGrid grid;
+  ClusterMemberTable t = makeRows(1, 16);
+  t.members[0].width = 0;  // the only member is off-grid
+  TEST_ASSERT_FALSE(validateMemberTable(t, grid).ok);
+}
+
+// A backup's row index is off-grid — even past the real rows it neither
+// demands contiguity for the rows it skips nor inflates the grid.
+static void test_zero_width_backup_high_row_ok() {
   ClusterGrid grid;
   ClusterMemberTable t = makeRows(2, 16);
+  t.count = 3;
+  snprintf(t.members[2].host, sizeof(t.members[2].host), "backup.local");
+  t.members[2].row = 6;
+  t.members[2].col = 0;
+  t.members[2].width = 0;
+  ClusterVerdict v = validateMemberTable(t, grid);
+  TEST_ASSERT_TRUE(v.ok);
+  TEST_ASSERT_EQUAL(2, grid.rows);
+}
+
+// A backup slices to an empty segment — the leader's fan-out skips it
+// (renderDirty gates on segment length), so it never renders.
+static void test_zero_width_backup_segment_empty() {
+  ClusterMemberTable t = makeRows(1, 16);
+  t.count = 2;
+  snprintf(t.members[1].host, sizeof(t.members[1].host), "backup.local");
+  t.members[1].row = 0;
+  t.members[1].col = 0;
   t.members[1].width = 0;
-  TEST_ASSERT_FALSE(validateMemberTable(t, grid).ok);
+  String segs[CLUSTER_MAX_MEMBERS];
+  TEST_ASSERT_TRUE(layoutGridText("HELLO", DisplayAlignment::Left, t, segs));
+  TEST_ASSERT_EQUAL(16, (int)segs[0].length());
+  TEST_ASSERT_TRUE(segs[0].startsWith("HELLO"));
+  TEST_ASSERT_EQUAL_STRING("", segs[1].c_str());
 }
 
 static void test_missing_row_rejected() {
@@ -472,7 +523,10 @@ int main(int, char**) {
   RUN_TEST(test_wide_rows_compose_from_side_by_side_members);
   RUN_TEST(test_empty_table_rejected);
   RUN_TEST(test_count_over_max_rejected);
-  RUN_TEST(test_zero_width_member_rejected);
+  RUN_TEST(test_zero_width_member_off_grid);
+  RUN_TEST(test_all_off_grid_table_rejected);
+  RUN_TEST(test_zero_width_backup_high_row_ok);
+  RUN_TEST(test_zero_width_backup_segment_empty);
   RUN_TEST(test_missing_row_rejected);
   RUN_TEST(test_table_without_row_zero_rejected);
   RUN_TEST(test_row_index_at_member_cap_rejected);

--- a/firmware/v2/Master/test/test_display_ipc/test_main.cpp
+++ b/firmware/v2/Master/test/test_display_ipc/test_main.cpp
@@ -432,6 +432,26 @@ static void test_width_override_out_of_range_is_ignored() {
   TEST_ASSERT_EQUAL(1, snap.displayWidth);
 }
 
+// #331 headless: a -1 override (deviceRole=headless-*) forces displayWidth 0
+// — the board renders nothing, beating even a full probe.
+static void test_width_override_headless_forces_zero_with_units() {
+  DisplaySnapshot snap;
+  UnitFacts facts[UNITS_AMOUNT];
+  for (int i = 0; i < UNITS_AMOUNT; i++) facts[i].state = 1;  // all present
+  displayApplyUnitFacts(snap, facts, UNITS_AMOUNT, -1);
+  TEST_ASSERT_EQUAL(0, snap.displayWidth);
+}
+
+// The .20 case: 0 units detected. Headless forces width 0 instead of the
+// ceiling fallback, so the board stops reporting a phantom full row.
+static void test_width_override_headless_zero_when_unitless() {
+  DisplaySnapshot snap;
+  UnitFacts facts[UNITS_AMOUNT];  // all silent
+  displayApplyUnitFacts(snap, facts, UNITS_AMOUNT, -1);
+  TEST_ASSERT_EQUAL(0, snap.displayWidth);
+  TEST_ASSERT_EQUAL(0, snap.detectedUnitCount);
+}
+
 int main(int, char**) {
   UNITY_BEGIN();
   RUN_TEST(test_fresh_snapshot_defaults);
@@ -468,5 +488,7 @@ int main(int, char**) {
   RUN_TEST(test_width_override_pins_width_with_no_units);
   RUN_TEST(test_width_override_zero_keeps_probe_behavior);
   RUN_TEST(test_width_override_out_of_range_is_ignored);
+  RUN_TEST(test_width_override_headless_forces_zero_with_units);
+  RUN_TEST(test_width_override_headless_zero_when_unitless);
   return UNITY_END();
 }

--- a/firmware/v2/Master/test/test_headless_policy/test_main.cpp
+++ b/firmware/v2/Master/test/test_headless_policy/test_main.cpp
@@ -1,0 +1,108 @@
+// Host-side tests for HeadlessPolicy.h (#329) — the pure no-units detection
+// debounce and deviceRole wire vocabulary behind the headless-mode feature.
+// No globals, no hardware: the whole policy runs natively.
+
+#include <ArduinoFake.h>
+#include <unity.h>
+
+#include "../../HeadlessPolicy.h"
+
+void setUp() {}
+void tearDown() {}
+
+// --- deviceRole validator ---------------------------------------------------
+
+static void test_role_validator_accepts_the_four_roles() {
+  TEST_ASSERT_TRUE(isValidDeviceRoleValue(String(DEVICE_ROLE_DISPLAY)));
+  TEST_ASSERT_TRUE(isValidDeviceRoleValue(String(DEVICE_ROLE_HEADLESS_BACKUP)));
+  TEST_ASSERT_TRUE(isValidDeviceRoleValue(String(DEVICE_ROLE_HEADLESS_MONITOR)));
+  TEST_ASSERT_TRUE(isValidDeviceRoleValue(String(DEVICE_ROLE_HEADLESS_SPARE)));
+}
+
+static void test_role_validator_rejects_case_empty_and_unknown() {
+  TEST_ASSERT_FALSE(isValidDeviceRoleValue(String("Display")));
+  TEST_ASSERT_FALSE(isValidDeviceRoleValue(String("")));
+  TEST_ASSERT_FALSE(isValidDeviceRoleValue(String("headless")));
+  TEST_ASSERT_FALSE(isValidDeviceRoleValue(String("backup")));
+}
+
+// --- isHeadlessRole ---------------------------------------------------------
+
+static void test_is_headless_role_true_for_the_three_headless_roles() {
+  TEST_ASSERT_TRUE(isHeadlessRole(String(DEVICE_ROLE_HEADLESS_BACKUP)));
+  TEST_ASSERT_TRUE(isHeadlessRole(String(DEVICE_ROLE_HEADLESS_MONITOR)));
+  TEST_ASSERT_TRUE(isHeadlessRole(String(DEVICE_ROLE_HEADLESS_SPARE)));
+}
+
+static void test_is_headless_role_false_for_display_and_junk() {
+  TEST_ASSERT_FALSE(isHeadlessRole(String(DEVICE_ROLE_DISPLAY)));
+  TEST_ASSERT_FALSE(isHeadlessRole(String("")));
+  TEST_ASSERT_FALSE(isHeadlessRole(String("nonsense")));
+}
+
+// --- detection debounce -----------------------------------------------------
+
+static void test_detector_needs_threshold_consecutive_zero_probes() {
+  HeadlessDetector d;
+  // Below threshold: not yet flagged.
+  TEST_ASSERT_FALSE(headlessObserveProbe(d, 0, 3));  // streak 1
+  TEST_ASSERT_FALSE(headlessObserveProbe(d, 0, 3));  // streak 2
+  // The Nth consecutive zero latches the suggestion.
+  TEST_ASSERT_TRUE(headlessObserveProbe(d, 0, 3));   // streak 3
+}
+
+static void test_detector_stays_true_and_saturates_past_threshold() {
+  HeadlessDetector d;
+  headlessObserveProbe(d, 0, 2);
+  TEST_ASSERT_TRUE(headlessObserveProbe(d, 0, 2));
+  // Many more zeros: stays true, streak counter must not overflow unbounded.
+  for (int i = 0; i < 1000; i++) {
+    TEST_ASSERT_TRUE(headlessObserveProbe(d, 0, 2));
+  }
+  TEST_ASSERT_TRUE(d.zeroStreak <= 2 + 1);  // saturated at/near threshold
+}
+
+static void test_a_single_unit_resets_the_streak() {
+  HeadlessDetector d;
+  headlessObserveProbe(d, 0, 3);  // streak 1
+  headlessObserveProbe(d, 0, 3);  // streak 2
+  // A real display whose units briefly reappear must never be flagged.
+  TEST_ASSERT_FALSE(headlessObserveProbe(d, 1, 3));  // reset
+  TEST_ASSERT_FALSE(headlessObserveProbe(d, 0, 3));  // streak 1 again
+  TEST_ASSERT_FALSE(headlessObserveProbe(d, 0, 3));  // streak 2
+  TEST_ASSERT_TRUE(headlessObserveProbe(d, 0, 3));   // streak 3
+}
+
+static void test_a_unit_after_latching_clears_the_suggestion() {
+  HeadlessDetector d;
+  headlessObserveProbe(d, 0, 1);  // latched true
+  TEST_ASSERT_TRUE(d.zeroStreak >= 1);
+  TEST_ASSERT_FALSE(headlessObserveProbe(d, 2, 1));  // units back -> cleared
+  TEST_ASSERT_EQUAL_INT(0, d.zeroStreak);
+}
+
+// --- headlessShouldSuggest --------------------------------------------------
+
+static void test_suggest_only_when_unitless_and_still_on_display_role() {
+  // Detected unit-less AND user hasn't picked a headless role yet -> nudge.
+  TEST_ASSERT_TRUE(headlessShouldSuggest(true, String(DEVICE_ROLE_DISPLAY)));
+  // Already headless: no nudge.
+  TEST_ASSERT_FALSE(headlessShouldSuggest(true, String(DEVICE_ROLE_HEADLESS_SPARE)));
+  TEST_ASSERT_FALSE(headlessShouldSuggest(true, String(DEVICE_ROLE_HEADLESS_BACKUP)));
+  // Units present: never nudge, whatever the role.
+  TEST_ASSERT_FALSE(headlessShouldSuggest(false, String(DEVICE_ROLE_DISPLAY)));
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_role_validator_accepts_the_four_roles);
+  RUN_TEST(test_role_validator_rejects_case_empty_and_unknown);
+  RUN_TEST(test_is_headless_role_true_for_the_three_headless_roles);
+  RUN_TEST(test_is_headless_role_false_for_display_and_junk);
+  RUN_TEST(test_detector_needs_threshold_consecutive_zero_probes);
+  RUN_TEST(test_detector_stays_true_and_saturates_past_threshold);
+  RUN_TEST(test_a_single_unit_resets_the_streak);
+  RUN_TEST(test_a_unit_after_latching_clears_the_suggestion);
+  RUN_TEST(test_suggest_only_when_unitless_and_still_on_display_role);
+  return UNITY_END();
+}

--- a/firmware/v2/Master/test/test_settings_json/test_main.cpp
+++ b/firmware/v2/Master/test/test_settings_json/test_main.cpp
@@ -157,6 +157,24 @@ static void test_unit_count_override_field_serializes() {
   TEST_ASSERT_TRUE(contains(json, "\"unitCountOverride\":8"));
 }
 
+static void test_device_role_defaults_to_display_and_no_suggestion() {
+  // #329: old UIs are unaffected — role defaults to "display" and the nudge
+  // is off until detection latches on a genuinely unit-less board.
+  SettingsJsonFields f;
+  String json = buildSettingsJson(f);
+  TEST_ASSERT_TRUE(contains(json, "\"deviceRole\":\"display\""));
+  TEST_ASSERT_TRUE(contains(json, "\"headlessSuggested\":false"));
+}
+
+static void test_device_role_and_suggestion_serialize() {
+  SettingsJsonFields f;
+  f.deviceRole = "headless-backup";
+  f.headlessSuggested = true;
+  String json = buildSettingsJson(f);
+  TEST_ASSERT_TRUE(contains(json, "\"deviceRole\":\"headless-backup\""));
+  TEST_ASSERT_TRUE(contains(json, "\"headlessSuggested\":true"));
+}
+
 int main(int, char**) {
   UNITY_BEGIN();
   RUN_TEST(test_defaults_produce_v1_shaped_empty_document);
@@ -168,5 +186,7 @@ int main(int, char**) {
   RUN_TEST(test_unit_arrays_carry_supplied_data);
   RUN_TEST(test_cluster_fields_carry_membership);
   RUN_TEST(test_unit_count_override_field_serializes);
+  RUN_TEST(test_device_role_defaults_to_display_and_no_suggestion);
+  RUN_TEST(test_device_role_and_suggestion_serialize);
   return UNITY_END();
 }

--- a/firmware/v2/Master/test/test_settings_json/test_main.cpp
+++ b/firmware/v2/Master/test/test_settings_json/test_main.cpp
@@ -175,6 +175,27 @@ static void test_device_role_and_suggestion_serialize() {
   TEST_ASSERT_TRUE(contains(json, "\"headlessSuggested\":true"));
 }
 
+// #335: per-board vitals so S3 cluster members surface in the System-tab
+// panel — same keys/units as the ESP-01 (heap/rssi/up), plus the plat tag.
+static void test_vitals_default_to_esp32s3_plat() {
+  SettingsJsonFields f;
+  String json = buildSettingsJson(f);
+  TEST_ASSERT_TRUE(contains(json, "\"plat\":\"esp32s3\""));
+  TEST_ASSERT_TRUE(contains(json, "\"heap\":0"));
+  TEST_ASSERT_TRUE(contains(json, "\"up\":0"));
+}
+
+static void test_vitals_serialize_values() {
+  SettingsJsonFields f;
+  f.heapBytes = 204800;
+  f.rssiDbm = -57;
+  f.upSeconds = 3600;
+  String json = buildSettingsJson(f);
+  TEST_ASSERT_TRUE(contains(json, "\"heap\":204800"));
+  TEST_ASSERT_TRUE(contains(json, "\"rssi\":-57"));
+  TEST_ASSERT_TRUE(contains(json, "\"up\":3600"));
+}
+
 int main(int, char**) {
   UNITY_BEGIN();
   RUN_TEST(test_defaults_produce_v1_shaped_empty_document);
@@ -188,5 +209,7 @@ int main(int, char**) {
   RUN_TEST(test_unit_count_override_field_serializes);
   RUN_TEST(test_device_role_defaults_to_display_and_no_suggestion);
   RUN_TEST(test_device_role_and_suggestion_serialize);
+  RUN_TEST(test_vitals_default_to_esp32s3_plat);
+  RUN_TEST(test_vitals_serialize_values);
   return UNITY_END();
 }

--- a/firmware/v2/Master/test/test_settings_post/test_main.cpp
+++ b/firmware/v2/Master/test/test_settings_post/test_main.cpp
@@ -408,6 +408,42 @@ static void test_apply_persists_unit_count_override() {
   TEST_ASSERT_EQUAL_INT(0, settings.unitCountOverride);
 }
 
+// --- device role (#329 headless mode) --------------------------------------
+
+static void test_device_role_defaults_to_display() {
+  FakeSettingsStore store;
+  MasterSettings settings = loadSettings(store);
+  TEST_ASSERT_EQUAL_STRING("display", settings.deviceRole.c_str());
+}
+
+static void test_stage_device_role_accepts_the_headless_roles() {
+  PendingSettingsPost post;
+  TEST_ASSERT_EQUAL(
+      (int)SettingsParamResult::Accepted,
+      (int)stageSettingsParam(post, PARAM_DEVICE_ROLE, "headless-monitor"));
+  TEST_ASSERT_TRUE(post.deviceRoleProvided);
+  TEST_ASSERT_EQUAL_STRING("headless-monitor", post.deviceRole.c_str());
+}
+
+static void test_stage_device_role_rejects_unknown() {
+  PendingSettingsPost post;
+  TEST_ASSERT_EQUAL(
+      (int)SettingsParamResult::Invalid,
+      (int)stageSettingsParam(post, PARAM_DEVICE_ROLE, "backup"));
+  TEST_ASSERT_FALSE(post.deviceRoleProvided);
+}
+
+static void test_apply_persists_device_role() {
+  FakeSettingsStore store;
+  MasterSettings settings = loadSettings(store);
+  PendingSettingsPost post;
+  stageSettingsParam(post, PARAM_DEVICE_ROLE, "headless-backup");
+  applySettingsPost(post, settings, store);
+  TEST_ASSERT_EQUAL_STRING("headless-backup", settings.deviceRole.c_str());
+  TEST_ASSERT_EQUAL_STRING("headless-backup",
+                           loadSettings(store).deviceRole.c_str());
+}
+
 int main(int, char**) {
   UNITY_BEGIN();
   RUN_TEST(test_unknown_param_is_ignored);
@@ -444,5 +480,9 @@ int main(int, char**) {
   RUN_TEST(test_stage_unit_count_accepts_and_trims);
   RUN_TEST(test_stage_unit_count_rejects_out_of_range);
   RUN_TEST(test_apply_persists_unit_count_override);
+  RUN_TEST(test_device_role_defaults_to_display);
+  RUN_TEST(test_stage_device_role_accepts_the_headless_roles);
+  RUN_TEST(test_stage_device_role_rejects_unknown);
+  RUN_TEST(test_apply_persists_device_role);
   return UNITY_END();
 }


### PR DESCRIPTION
## Headless mode for a unit-less ESP32-S3 master (#329) + cluster UI/vitals fixes

Gives a unit-less S3 a useful identity instead of a phantom display row, and fixes several cluster-UI gaps surfaced while bench-testing it. Detection only ever **suggests** a role — the user confirms; nothing self-demotes.

### Headless mode (epic #329)
- **Slice 1 (#329)** — pure `HeadlessPolicy.h`: `deviceRole` vocabulary (`display` / `headless-{backup,monitor,spare}`) + validator, and a no-units detection debounce (N consecutive 0-unit probes) feeding `DisplaySnapshot.headlessUnitless`. NVS `deviceRole` knob; `/settings` surfaces `deviceRole` + `headlessSuggested`.
- **Slice 2 (#330)** — Web-UI **Device role** card on the Maintenance tab (mirrors the `deviceMode` segmented control), with a current-role pill and an amber "this board detects no units — pick a headless role" banner driven by `headlessSuggested`.
- **Slice 3a (#331)** — a headless `deviceRole` forces `displayWidth = 0` (a `-1` sentinel on `displayApplyUnitFacts`, beating both the probe ceiling-fallback and the #289 override). This is what makes the selector *functional*: a unit-less master stops faking a full row of silent units.
- **Slice 3c (#333)** — a width-0 cluster member is now **off-grid**: full membership (pings, digest, HMAC, promote rank) but no columns and no wall row, and it's the **preferred rank-0 successor** (no row of its own to lose). A unit-less S3 can join a wall as a non-rendering, promote-eligible warm standby. Fixes the member-editor rejecting width 0.

Emergent: because the leader's own row width tracks `displayWidth`, toggling a board to a headless role makes it drop out of the wall automatically (slice 3a + 3c combine).

### Cluster UI / observability fixes
- **#334** — the cluster member table now shows the firmware rev for "(this board)" and a platform label for every row (`esp32s3` / `esp01`), not just ESP-01.
- **#335** — the S3 `/settings` now carries `heap`/`rssi`/`up`/`plat` (same keys/units as the ESP-01 follower), so the System-tab "Cluster members" vitals panel shows Free Heap / RSSI / Uptime for S3 rows too — previously ESP-01-only.

### Deferred (still open)
- **#332** — cluster-monitor role (the last headless slice).
- **#333 physical drill** — leader power-loss → width-0 backup auto-promote (bench, needs hardware participation).

## Test plan
- [x] `pio test -e native` — **748/748** green (new: `test_headless_policy`, plus extended `test_display_ipc` / `test_cluster_layout` / `test_cluster_digest` / `test_settings_json` / `test_settings_post`).
- [x] `pio run` (Master) builds clean.
- [x] cpp-review (cluster-wire #333 + concurrency #331) — both APPROVE after fixing 2 MEDIUM in #333 (off-grid self-row health anchor + all-off-grid floor).
- [x] Bench on `.20`/`.91`/`.121` (fleet on `2e1e011`):
  - `.20` unit-less → `headlessSuggested:true`; setting `headless-spare` drops `displayWidth 16→0` and its cluster row to off-grid (both phantoms gone).
  - `POST /cluster/config` with a width-0 member accepted (was `400 "Member width must be at least 1"`).
  - member table shows "(this board)" rev + `esp32s3`; System-tab vitals populated for all three members.
- [ ] Physical: width-0 backup auto-promote on leader power-loss (#333 drill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
