### PR TITLE
fix(#342,#362): ESP-01 clock fallback shows local time, not UTC

### DIFF
--- a/firmware/v2/FollowerEsp01/FollowerClock.h
+++ b/firmware/v2/FollowerEsp01/FollowerClock.h
@@ -33,6 +33,15 @@ inline void followerClockText(int hour, int minute, int width, char* out) {
   for (int i = 0; i < 5 && left + i < width; i++) out[left + i] = hhmm[i];
 }
 
+// #362: the epoch→local-HH:MM conversion is NOT here — it is target libc
+// glue (bench tier). On the ESP8266, setenv("TZ")+tzset() is INERT for
+// localtime_r; the zone must be installed via the core's configTime(tz)
+// (which drives newlib's __gettzinfo), done from loop context in
+// FollowerCluster.cpp. A host-side test would use glibc's fully-working
+// tzset and pass while the target renders UTC — actively misleading — so the
+// tz application is proven on the bench, not natively. `followerClockText`
+// (pure formatting) stays natively tested.
+
 // The fallback runs ONLY in Blank with a held membership (the tz belongs
 // to a leader we still expect back), a known zone, and synced time.
 // Standalone (never joined / left) stays dark — no membership, no zone.

--- a/firmware/v2/FollowerEsp01/FollowerCluster.cpp
+++ b/firmware/v2/FollowerEsp01/FollowerCluster.cpp
@@ -64,13 +64,18 @@ static uint64_t nowEpochMs(bool& synced) {
   return (uint64_t)t * 1000ULL + (millis() % 1000);
 }
 
-// #342: publish the leader's zone to libc so localtime() speaks it. Safe
-// pre-WiFi (it's just the TZ env var); SNTP keeps feeding raw epoch.
-static void applyLeaderTz() {
-  if (leaderTz.length() == 0) return;
-  setenv("TZ", leaderTz.c_str(), 1);
-  tzset();
-}
+// #342/#362: the leader's zone is installed via the ESP8266 core's
+// configTime(tz) (which drives newlib's __gettzinfo) from LOOP context —
+// bench-proven that a bare setenv+tzset is INERT for localtime_r here, and
+// that configTime re-inits SNTP so it must never run from an async handler.
+// It also must run AFTER wifiServicesInit's configTime(0,0) (which resets the
+// zone to UTC) — the loop is, clusterInit isn't. This just marks a (re)install
+// as needed; clusterLoopTick does it lazily once SNTP is synced.
+// volatile: cleared from the async-handler context (clusterHandleJoin ->
+// applyLeaderTz), read+set from loop context — same cross-context idiom as
+// membershipDirty/renderPending above.
+static volatile bool tzInstalled = false;
+static void applyLeaderTz() { tzInstalled = false; }
 
 void clusterInit() {
   EEPROM.begin(FOLLOWER_MEMBERSHIP_BLOB_LEN);
@@ -150,20 +155,30 @@ void clusterLoopTick() {
     (void)nowEpochMs(synced);
     if (followerClockEligible(policyState.phase, leaderHost.length() > 0,
                               leaderTz.length() > 0, synced)) {
-      time_t t = time(nullptr);
+      // #362: install the leader's zone lazily, here in loop context, the
+      // first time a fallback actually needs it (and after any zone change).
+      // configTime installs it synchronously via setTZ before returning, so
+      // the localtime_r below is already correct this same tick. Latched, so
+      // the SNTP re-init cost is paid once per fallback episode, not per tick.
+      if (!tzInstalled) {
+        configTime(leaderTz.c_str(), "pool.ntp.org");
+        tzInstalled = true;
+      }
+      time_t nowT = time(nullptr);
       struct tm lt;
-      localtime_r(&t, &lt);
-      if ((!clockShowing || lt.tm_min != shownClockMinute) &&
+      localtime_r(&nowT, &lt);
+      int hour = lt.tm_hour, minute = lt.tm_min;
+      if ((!clockShowing || minute != shownClockMinute) &&
           !renderPending && !reflashInProgress(reflashProgress)) {
         if (!clockShowing) {
           SerialPrintln(F("cluster: leader lost — local clock fallback"));
         }
         int width = displayWidth > 0 ? displayWidth : UNITS_AMOUNT;
         char text[UNITS_AMOUNT + 1];
-        followerClockText(lt.tm_hour, lt.tm_min, width, text);
+        followerClockText(hour, minute, width, text);
         busShowSegment(String(text), heldSpeed > 0 ? heldSpeed : 80);
         clockShowing = true;
-        shownClockMinute = lt.tm_min;
+        shownClockMinute = minute;
         rowIsBlank = false;
       }
       return;
@@ -302,6 +317,8 @@ void clusterHandleLeave() {
   leaderName = "";
   leaderHost = "";
   leaderTz = "";  // #342: the zone leaves with the leader that owned it
+  applyLeaderTz();  // #362: re-arm the tz latch (defensive — eligibility also
+                    // gates on leaderTz, but this survives a future refactor)
   memberRow = 0;
   heldSegment = "";
   renderPending = false;


### PR DESCRIPTION
Closes #362.

The #342 lost-leader clock fallback rendered **UTC** instead of the leader's zone. Found + fixed + bench-proven this session.

## Root cause (bench-established; a host test can't see it)
1. `setenv("TZ",…)+tzset()` is **inert** for `localtime_r` on the ESP8266 core — the zone must go through `configTime(tz)` (which drives newlib's `__gettzinfo`). Proven live: `setenv`+`tzset`+`localtime_r` returned `localH == utcH`.
2. The zone was applied at `clusterInit`, *before* `wifiServicesInit`'s `configTime(0,0)` reset it to UTC, and the rejoin skipped re-applying (`tzChanged=false`) — so nothing ever re-installed it.

## Fix
Install the leader's POSIX zone with `configTime(leaderTz, "pool.ntp.org")` from **loop context** (never an async handler — `configTime` re-inits SNTP), lazily on the first fallback that needs it and re-armed on any zone change (`applyLeaderTz` now just clears the `tzInstalled` latch). `configTime` sets the zone synchronously before returning, so the same-tick `localtime_r` is correct; `time()` stays UTC so commitAt flip-sync is unaffected.

## Testing philosophy correction
The epoch→local conversion is **target libc glue (bench tier)**, not natively tested: a host test uses glibc's fully-working `tzset` and would pass while the target renders UTC — actively misleading. Removed that false-green helper + its 3 tests; `followerClockText` (pure formatting) stays natively tested.

## Verification
- Isolation reads on .121: `configTime(leaderTz)` from loop → `utcH=20, localH=22` (CEST) simultaneously.
- **End-to-end**: leader offline ~3 min → .121 reached Blank → units physically showed `22:24` at 22:24 local wall time (was `19:32` before the fix). Cluster reconverged cleanly after.
- 84 follower native + 14 pytest green; follower builds.

## Test plan
- [x] Native + pytest green
- [x] Bench: real leader outage renders correct local time on the units
- [ ] CI on this PR